### PR TITLE
[QoL] add `common:money` key

### DIFF
--- a/de/common.json
+++ b/de/common.json
@@ -4,5 +4,6 @@
   "shinyOnHover": "Schillernd",
   "commonShiny": "Gewöhnlich",
   "rareShiny": "Selten",
-  "epicShiny": "Episch"
+  "epicShiny": "Episch",
+  "money": "{{amount, number}} ₽"
 }

--- a/en/common.json
+++ b/en/common.json
@@ -4,5 +4,6 @@
   "shinyOnHover": "Shiny",
   "commonShiny": "Common",
   "rareShiny": "Rare",
-  "epicShiny": "Epic"
+  "epicShiny": "Epic",
+  "money": "₽{{amount, number}}"
 }

--- a/es/common.json
+++ b/es/common.json
@@ -4,5 +4,6 @@
   "shinyOnHover": "Shiny",
   "commonShiny": "Común",
   "rareShiny": "Raro",
-  "epicShiny": "Épico"
+  "epicShiny": "Épico",
+  "money": "{{amount, number}} ₽"
 }

--- a/fr/common.json
+++ b/fr/common.json
@@ -4,5 +4,6 @@
   "shinyOnHover": "Chromatique",
   "commonShiny": "Commun",
   "rareShiny": "Rare",
-  "epicShiny": "Épique"
+  "epicShiny": "Épique",
+  "money": "{{amount, number}} ₽"
 }

--- a/it/common.json
+++ b/it/common.json
@@ -4,5 +4,6 @@
   "shinyOnHover": "Shiny",
   "commonShiny": "Comune",
   "rareShiny": "Raro",
-  "epicShiny": "Epico"
+  "epicShiny": "Epico",
+  "money": "{{amount, number}} ₽"
 }

--- a/ja/common.json
+++ b/ja/common.json
@@ -4,5 +4,6 @@
   "shinyOnHover": "色違い",
   "commonShiny": "ふつう",
   "rareShiny": "レア",
-  "epicShiny": "超レア"
+  "epicShiny": "超レア",
+  "money": "{{amount, number}}円"
 }


### PR DESCRIPTION
> [!TIP]
> https://github.com/pagefaultgames/pokerogue/pull/4550

derived from this code:

```ts
 switch (lng) {
    case "ja":
      return `@[MONEY]{${numberFormattedString}}円`;
    case "de":
    case "es":
    case "fr":
    case "it":
      return `@[MONEY]{${numberFormattedString} ₽}`;
    default:
      // English and other languages that use same format
      return `@[MONEY]{₽${numberFormattedString}}`;
    }
 ```

--------

# EN 

<img width="954" alt="image" src="https://github.com/user-attachments/assets/b14653fc-5dff-4a4d-8435-9941f2505eab">

# DE

<img width="953" alt="image" src="https://github.com/user-attachments/assets/f50b1cd5-0a14-49ab-bb51-2cd6ddd7929f">

# JA

<img width="948" alt="image" src="https://github.com/user-attachments/assets/a55df66c-dda7-42c9-98bf-370ed12d9bf8">

# ES

<img width="970" alt="image" src="https://github.com/user-attachments/assets/2ed64415-ab40-484e-93d1-2f9a97dc8b9e">

# FR

<img width="960" alt="image" src="https://github.com/user-attachments/assets/9a9e301d-f1fd-48ae-9f72-3b4ad294ef14">

# IT

<img width="972" alt="image" src="https://github.com/user-attachments/assets/152fcfc3-bf1b-4560-87b1-56f993a466ba">