### PR TITLE
[Move] Add translations for Pledge Moves

### DIFF
--- a/en/arena-tag.json
+++ b/en/arena-tag.json
@@ -54,5 +54,15 @@
   "safeguardOnAddEnemy": "The opposing team cloaked itself in a mystical veil!",
   "safeguardOnRemove": "The field is no longer protected by Safeguard!",
   "safeguardOnRemovePlayer": "Your team is no longer protected by Safeguard!",
-  "safeguardOnRemoveEnemy": "The opposing team is no longer protected by Safeguard!"
+  "safeguardOnRemoveEnemy": "The opposing team is no longer protected by Safeguard!",
+  "fireGrassPledgeOnAdd": "A sea of fire enveloped the field!",
+  "fireGrassPledgeOnAddPlayer": "A sea of fire enveloped your team!",
+  "fireGrassPledgeOnAddEnemy": "A sea of fire enveloped the opposing team!",
+  "fireGrassPledgeLapse": "{{pokemonNameWithAffix}} was hurt by the sea of fire!",
+  "waterFirePledgeOnAdd": "A rainbow appeared in the sky!",
+  "waterFirePledgeOnAddPlayer": "A rainbow appeared in the sky on your team's side!",
+  "waterFirePledgeOnAddEnemy": "A rainbow appeared in the sky on the opposing team's side!",
+  "grassWaterPledgeOnAdd": "A swamp enveloped the field!",
+  "grassWaterPledgeOnAddPlayer": "A swamp enveloped your team!",
+  "grassWaterPledgeOnAddEnemy": "A swamp enveloped the opposing team!"
 }

--- a/en/move-trigger.json
+++ b/en/move-trigger.json
@@ -71,5 +71,7 @@
   "safeguard": "{{targetName}} is protected by Safeguard!",
   "substituteOnOverlap": "{{pokemonName}} already\nhas a substitute!",
   "substituteNotEnoughHp": "But it does not have enough HP\nleft to make a substitute!",
-  "afterYou": "{{targetName}} took the kind offer!"
+  "afterYou": "{{targetName}} took the kind offer!",
+  "combiningPledge": "The two moves have become one!\nIt's a combined move!",
+  "awaitingPledge": "{{userPokemonName}} is waiting for {{allyPokemonName}}'s move..."
 }


### PR DESCRIPTION
To coincide with the implementation of Water Pledge, Fire Pledge, and Grass Pledge in https://github.com/pagefaultgames/pokerogue/pull/4511. The added English keys have previously been approved by proofreaders.