### PR TITLE
Nuzlocke challenges EN keys

### DIFF
--- a/en/challenges.json
+++ b/en/challenges.json
@@ -33,5 +33,23 @@
     "desc": "Type matchups are reversed and no type is immune to any other type.\nDisables other challenges' achievements.",
     "value.0": "Off",
     "value.1": "On"
+  },
+  "noAutoHeal": {
+    "name": "No Free Heal",
+    "desc": "Disables the free automatic healing which normally occurs after every 10th wave.",
+    "value.0": "Off",
+    "value.1": "On"
+  },
+  "hardcore": {
+    "name": "Hardcore",
+    "desc": "You can no longer revive Pokémon that have fainted.",
+    "value.0": "Off",
+    "value.1": "On"
+  },
+  "limitedCatch": {
+    "name": "Limited Catch",
+    "desc": "You can only add the first Pokémon of a biome to your current party.",
+    "value.0": "Off",
+    "value.1": "On"
   }
 }


### PR DESCRIPTION
Spun off from the [Nuzlocke PR](https://github.com/pagefaultgames/pokerogue/pull/4311).
Already proofread. https://github.com/pagefaultgames/pokerogue/pull/4311#pullrequestreview-2337907769
![image](https://github.com/user-attachments/assets/1014b67c-250e-48c6-8524-ff23fdb7e594)
