### PR TITLE
[Move][Translation] Electrify

### DIFF
--- a/en/battler-tags.json
+++ b/en/battler-tags.json
@@ -80,5 +80,6 @@
   "imprisonOnAdd": "{{pokemonNameWithAffix}} sealed the opponents move(s)!",
   "autotomizeOnAdd": "{{pokemonNameWithAffix}} became nimble!",
   "syrupBombOnAdd": "{{pokemonNameWithAffix}} got covered in sticky, candy syrup!",
-  "syrupBombLapse": "The sticky syrup slowed down {{pokemonNameWithAffix}}!"
+  "syrupBombLapse": "The sticky syrup slowed down {{pokemonNameWithAffix}}!",
+  "electrifiedOnAdd": "{{pokemonNameWithAffix}}'s moves have been electrified!"
 }


### PR DESCRIPTION
Adds one key with English text for the move [Electrify](https://bulbapedia.bulbagarden.net/wiki/Electrify_(move)) as implemented with https://github.com/pagefaultgames/pokerogue/pull/4569

Source for English text: https://youtu.be/s5ZtTLGivZs?si=gkDay_cuM1e8DypP&t=114