### PR TITLE
[Misc][EN] Default messages for disabled switch/run commands

### DIFF
--- a/en/battle.json
+++ b/en/battle.json
@@ -65,6 +65,8 @@
   "noEscapeForce": "An unseen force\nprevents escape.",
   "noEscapeTrainer": "You can't run\nfrom a trainer battle!",
   "noEscapePokemon": "{{pokemonName}}'s {{moveName}}\nprevents {{escapeVerb}}!",
+  "noEscapeSwitch": "The Pokémon can't be switched out!",
+  "noEscapeFlee": "The Pokémon can't escape!",
   "runAwaySuccess": "You got away safely!",
   "runAwayCannotEscape": "You can't escape!",
   "escapeVerbSwitch": "switching",


### PR DESCRIPTION
New keys for default messages when an effect that's not a trapping ability or move prevents Pokemon from switching or fleeing.

First used in https://github.com/pagefaultgames/pokerogue/pull/4670

Source (for switching):

![image](https://github.com/user-attachments/assets/53068c45-9b54-41d0-89ed-543f33af0c2e)