### PR TITLE
Updated pokeball modifier

### DIFF
--- a/en/modifier-type.json
+++ b/en/modifier-type.json
@@ -1,8 +1,9 @@
 {
   "ModifierType": {
     "AddPokeballModifierType": {
-      "name": "{{modifierCount}}x {{pokeballName}}",
-      "description": "Receive {{pokeballName}} x{{modifierCount}} (Inventory: {{pokeballAmount}}) \nCatch Rate: {{catchRate}}"
+      "name": "{{pokeballName}} x{{modifierCount}}\nInventory: {{pokeballAmount}}",
+      "description": "Catch Rate: {{catchRate}}",
+      "catchRateGenerator": "{{normalCatchRate}}x ({{boostedCatchRate}}x if Pokémon has new gender, variant, form, or ability)"
     },
     "AddVoucherModifierType": {
       "name": "{{modifierCount}}x {{voucherTypeName}}",


### PR DESCRIPTION
Locales update for [the rogue balance update PR](https://github.com/pagefaultgames/pokerogue/pull/4065)

Changed it so that the pokeball name is now two lines, with the first showing the pokeball's name and how many you'll receive, and the second line showing how many you have in your inventory. The description is now replaced by just the catch rate, unless it's a rogue ball in which it tells you about the boosted catch rate for pokemon with tinted pokeballs. See below for an example of a rouge ball in the shop:

![369071467-d1c00d81-de80-4741-9538-608669335612](https://github.com/user-attachments/assets/642623ef-e746-4a59-8a92-6f939c65bdee)
