### PR TITLE
[EN] Arena flyout descriptors for Pledge combinations, Ion Deluge, and Lucky Chant

### DIFF
--- a/en/arena-flyout.json
+++ b/en/arena-flyout.json
@@ -40,5 +40,10 @@
   "craftyShield": "Crafty Shield",
   "tailwind": "Tailwind",
   "happyHour": "Happy Hour",
-  "safeguard": "Safeguard"
+  "safeguard": "Safeguard",
+  "noCrit": "Lucky Chant",
+  "ionDeluge": "Ion Deluge",
+  "fireGrassPledge": "Sea of Fire",
+  "waterFirePledge": "Rainbow",
+  "grassWaterPledge": "Swamp"
 }


### PR DESCRIPTION
I missed these keys when implementing their respective moves :despair:

Text is straightforward for the most part, being derived from the source move's name or, in the case of the Pledge combos, the effect descriptors from [Bulbapedia](https://bulbapedia.bulbagarden.net/wiki/Fire_Pledge_(move)).