### PR TITLE
[EN] Multi-Lens description update

### DIFF
--- a/en/modifier-type.json
+++ b/en/modifier-type.json
@@ -109,7 +109,7 @@
       "description": "Increases move accuracy by {{accuracyAmount}} (maximum 100)."
     },
     "PokemonMultiHitModifierType": {
-      "description": "Attacks hit one additional time at the cost of a 60/75/82.5% power reduction per stack respectively."
+      "description": "Converts 25% of damage from the holder's attacks into an additional strike."
     },
     "TmModifierType": {
       "name": "TM{{moveId}} - {{moveName}}",


### PR DESCRIPTION
> [!IMPORTANT]
> This updated description is based on balance changes to Multi-Lens in https://github.com/pagefaultgames/pokerogue/pull/4831. This PR should only be merged in after the balance changes have been approved by Devs and the Balance Team.

This changes a custom description for Multi-Lens to reflect planned changes to the item. The changes in detail are listed below:
- The maximum stack count for this item has been reduced from 3 to 2.
- The power reduction per hit has changed to a damage modifier such that
  - 1x Multi-Lens changes from 40% * 2 _power_ -> 75% + 25% _damage_.
  - 2x Multi-Lens changes from 25% * 3 _power_ -> 50% + 25% + 25% _damage_.
- The item now adheres to the same restrictions as [Parental Bond](https://bulbapedia.bulbagarden.net/wiki/Parental_Bond_(Ability)) (i.e. it no longer affects multi-hit moves, multi-target moves, charge moves, and some other edge cases).
- The item now stacks additively with Parental Bond instead of multiplicatively, with the added strike from Parental Bond always dealing 25% damage.