### PR TITLE
Add number of eggs hatching to egg skip prompt

### DIFF
--- a/en/battle.json
+++ b/en/battle.json
@@ -77,7 +77,7 @@
   "skipItemQuestion": "Are you sure you want to skip taking an item?",
   "itemStackFull": "The stack for {{fullItemName}} is full.\nYou will receive {{itemName}} instead.",
   "eggHatching": "Oh?",
-  "eggSkipPrompt": "Skip to egg summary?",
+  "eggSkipPrompt": "{{eggsToHatch}} eggs are ready to hatch.\nSkip to egg summary?",
   "ivScannerUseQuestion": "Use IV Scanner on {{pokemonName}}?",
   "wildPokemonWithAffix": "Wild {{pokemonName}}",
   "foePokemonWithAffix": "Foe {{pokemonName}}",

--- a/fr/battle.json
+++ b/fr/battle.json
@@ -77,7 +77,7 @@
   "skipItemQuestion": "Êtes-vous sûr·e de ne pas vouloir prendre d’objet ?",
   "itemStackFull": "Quantité maximale de {{fullItemName}} atteinte.\nVous recevez {{itemName}} à la place.",
   "eggHatching": "Hein ?",
-  "eggSkipPrompt": "Il y a {{eggsToHatch}} Œufs prêts à éclore.\nAller directement au résumé des éclosions ?",
+  "eggSkipPrompt": "Il y a {{eggsToHatch}} Œuf·s prêts à éclore.\nAller directement au résumé des éclosions ?",
   "ivScannerUseQuestion": "Utiliser le Scanner d’IV\nsur {{pokemonName}} ?",
   "wildPokemonWithAffix": "{{pokemonName}} sauvage",
   "foePokemonWithAffix": "{{pokemonName}} ennemi",

--- a/fr/battle.json
+++ b/fr/battle.json
@@ -77,7 +77,7 @@
   "skipItemQuestion": "Êtes-vous sûr·e de ne pas vouloir prendre d’objet ?",
   "itemStackFull": "Quantité maximale de {{fullItemName}} atteinte.\nVous recevez {{itemName}} à la place.",
   "eggHatching": "Hein ?",
-  "eggSkipPrompt": "Il y a {{eggsToHatch}} Œuf·s prêts à éclore.\nAller directement au résumé des éclosions ?",
+  "eggSkipPrompt": "Aller directement au résumé des Œufs éclos ?",
   "ivScannerUseQuestion": "Utiliser le Scanner d’IV\nsur {{pokemonName}} ?",
   "wildPokemonWithAffix": "{{pokemonName}} sauvage",
   "foePokemonWithAffix": "{{pokemonName}} ennemi",

--- a/fr/battle.json
+++ b/fr/battle.json
@@ -77,7 +77,7 @@
   "skipItemQuestion": "Êtes-vous sûr·e de ne pas vouloir prendre d’objet ?",
   "itemStackFull": "Quantité maximale de {{fullItemName}} atteinte.\nVous recevez {{itemName}} à la place.",
   "eggHatching": "Hein ?",
-  "eggSkipPrompt": "Aller directement au résumé des Œufs éclos ?",
+  "eggSkipPrompt": "Il y a {{eggsToHatch}} Œufs prêts à éclore.\nAller directement au résumé des éclosions ?",
   "ivScannerUseQuestion": "Utiliser le Scanner d’IV\nsur {{pokemonName}} ?",
   "wildPokemonWithAffix": "{{pokemonName}} sauvage",
   "foePokemonWithAffix": "{{pokemonName}} ennemi",


### PR DESCRIPTION
Goes with [PRPR#4913](https://github.com/pagefaultgames/pokerogue/pull/4913).

Implements the `eggsToHatch` argument passed to `eggSkipPrompt` in `battle.json`. This is intended to show the player how many eggs are about to hatch when prompted on whether to skip to egg summary, as seen below:

![image](https://github.com/user-attachments/assets/702bdc50-5a4c-4d72-ac1c-9204e0c22783)
