### PR TITLE
Properly capitalize Make It Rain splash text

### DIFF
--- a/en/splash-texts.json
+++ b/en/splash-texts.json
@@ -116,7 +116,7 @@
   "keepItCasual": "Keep It Casual!",
   "serversProbablyWorking": "Servers Probably Working!",
   "mew": "Mew Probably Not Under a Truck!",
-  "makeItRainAndYourProblemsGoAway": "Make it Rain and your problems go away!",
+  "makeItRainAndYourProblemsGoAway": "Make It Rain and your problems go away!",
   "customMusicTracks": "Custom Music Tracks!",
   "youAreValid": "You Are Valid!",
   "number591IsLookingOff": "Number 591 Is Looking a Bit...",


### PR DESCRIPTION
"Make it Rain and your problems go away!" -> "Make It Rain and your problems go away!"

The move name has "It" capitalized.