### PR TITLE
Add confirmation message for disabling touch controls in settings

### DIFF
--- a/en/settings.json
+++ b/en/settings.json
@@ -107,5 +107,7 @@
   "rewards": "Rewards",
   "reroll": "Reroll",
   "shop": "Shop",
-  "checkTeam": "Check Team"
+  "checkTeam": "Check Team",
+  "confirmDisableTouch": "Are you sure you want to disable Touch Controls?",
+  "defaultConfirmMessage": "Are you sure?"
 }

--- a/fr/settings.json
+++ b/fr/settings.json
@@ -108,6 +108,6 @@
   "reroll": "Relance",
   "shop": "Boutique",
   "checkTeam": "Équipe",
-  "confirmDisableTouch": "Êtes-vous sur·e de vouloir désactiver les contrôles tactiles ?",
+  "confirmDisableTouch": "Êtes-vous sûr·e de vouloir désactiver les contrôles tactiles ?",
   "defaultConfirmMessage": "Confirmer ?"
 }

--- a/fr/settings.json
+++ b/fr/settings.json
@@ -107,5 +107,7 @@
   "rewards": "Obj. gratuits",
   "reroll": "Relance",
   "shop": "Boutique",
-  "checkTeam": "Équipe"
+  "checkTeam": "Équipe",
+  "confirmDisableTouch": "Êtes-vous sur·e de vouloir désactiver les contrôles tactiles ?",
+  "defaultConfirmMessage": "Confimer ?"
 }

--- a/fr/settings.json
+++ b/fr/settings.json
@@ -109,5 +109,5 @@
   "shop": "Boutique",
   "checkTeam": "Équipe",
   "confirmDisableTouch": "Êtes-vous sur·e de vouloir désactiver les contrôles tactiles ?",
-  "defaultConfirmMessage": "Confimer ?"
+  "defaultConfirmMessage": "Confirmer ?"
 }


### PR DESCRIPTION
Link to main repo PR: https://github.com/pagefaultgames/pokerogue/pull/4949

This PR adds a confirmation message in settings before disabling touch controls, like so:
![image](https://github.com/user-attachments/assets/b66b8adf-7c12-4e9e-b8e4-7f96115eb056)

The Yes/No is the generic Yes/No window used across the game, no need to do anything on that front

The text box can display 2 lines, with automatic wrap around so no need to bother about line breaks and there should be plenty of room.
For proofreaders, do you think something else should be added to make extra clear that if they don't have access to another mean to control the game they will get locked out if they say yes? That shouldn't be needed, right?

The second key "defaultConfirmMessage" is not used currently in the game, but if in the future a setting is added that does not need a specific confirmation message it will get used automatically