### PR TITLE
Add holiday splashes in English

### DIFF
--- a/en/splash-texts.json
+++ b/en/splash-texts.json
@@ -123,23 +123,61 @@
     "number591IsLookingOff": "Number 591 Is Looking a Bit...",
     "timeForYourDeliDelivery": "Time for Your Deli-Delivery!",
     "goodFirstImpression": "Hope We Left a Good First Impression!",
-    "iPreferRarerCandies": "I Prefer Rarer Candies!"
+    "iPreferRarerCandies": "I Prefer Rarer Candies!",
+    "vgc_ref_1": "Wolfe Con Perish???",
+    "agency_ref_1": "I Goobed!",
+    "pkmn_cry_1": "DEELEELEEWOOOOP!"
   },
   "halloween": {
     "pumpkabooAbout": "Pumpkaboo About!",
     "mayContainSpiders": "May Contain Spiders!",
     "spookyScarySkeledirge": "Spooky, Scary Skeledirge!",
     "gourgeistUsedTrickOrTreat": "Gourgeist Used Trick-or-Treat!",
-    "letsSnuggleForever": "Let's Snuggle Forever!"
+    "letsSnuggleForever": "Let's Snuggle Forever!",
+    "halloween_1": "BOO!"
   },
   "xmas": {
     "happyHolidays": "Happy Holidays!",
     "delibirdSeason": "Delibird Season!",
     "unaffilicatedWithDelibirdServices": "Unaffiliated With Delibird Services!",
     "diamondsFromTheSky": "Diamonds From the Sky!",
-    "holidayStylePikachuNotIncluded": "Holiday Style Pikachu Not Included!"
+    "holidayStylePikachuNotIncluded": "Holiday Style Pikachu Not Included!",
+    "winter_1": "Are You Naughty or Jolly?",
+    "winter_2": "And to All a Good Night!",
+    "winter_3": "Merry Happy!",
+    "winter_4": "Feliz Navi Squad!",
+    "winter_5": "Have an Ice Day!",
+    "winter_6": "Nothing Beats an Oil-Fried Donut!",
+    "winter_7": "Let it Snom!",
+    "winter_8": "It's Snover!",
+    "winter_9": "We're So Baxcalibur!",
+    "winter_10": "You Better Watch Out!",
+    "winter_11": "Don't You Feel Jolly? Don't You Feel Merry? Don't You Feel a Little Bit Festive?",
+    "winter_12": "Ho-Oh-Oh!",
+    "winter_13": "Spin the Claydol!",
+    "winter_14": "Be Good, For Goodness Sake!",
+    "winter_15": "Moomoo Milk and Lava Cookies!",
+    "winter_16": "Chocolate is Not Legal Tender!",
+    "winter_17": "I Need a Yache Berry...",
+    "winter_18": "Get Jolly! Or Don't!",
+    "winter_19": "Live Chien-Pao Reaction:",
+    "winter_20": "Chingling All the Way!",
+    "winter_21": "Deck the Halls!",
+    "winter_22": "Rushing Through the Slush!",
+    "winter_23": "No Time Like the Present!",
+    "winter_24": "Gelty Gear!",
+    "winter_25": "Save Scumming Gets You On the Naughty List!",
+    "winter_26": "Stockings Full of Rolycoly!",
+    "winter_27": "Do You Wanna Build a Darmanitan-Galar-Zen?",
+    "winter_28": "Try Egg Nog for Extra Gacha Luck!",
+    "winter_29": "Happy Holidays!",
+    "winter_30": "Happy Holidays!",
+    "winter_31": "Happy Holidays!",
+    "winter_32": "Happy Holidays!"
   },
   "newYears": {
-    "happyNewYear": "Happy New Year!"
+    "happyNewYear": "Happy New Year!",
+    "newyears_1": "...And a Happy New Year!",
+    "newyears_2": "Try Egg Nog for Extra Gacha Luck!"
   }
 }


### PR DESCRIPTION
Adds keys for `winter_1` through `winter_32` in the `xmas` category. English has 28 of these filled (subject to change), the rest are "Happy Holidays!" as a placeholder. Also adds splashes with more generic keys:
- common.vgc_ref_1
- common.agency_ref_1
- common.pkmn_cry_1
- halloween.halloween_1
- newYears.newyears_1
- newYears.newyears_2