### PR TITLE
Moving the "Run History" option

### DIFF
--- a/de/menu-ui-handler.json
+++ b/de/menu-ui-handler.json
@@ -2,7 +2,6 @@
   "GAME_SETTINGS": "Spieleinstellungen",
   "ACHIEVEMENTS": "Erfolge",
   "STATS": "Statistiken",
-  "RUN_HISTORY": "Laufhistorie",
   "EGG_LIST": "Eierliste",
   "EGG_GACHA": "Eier-Gacha",
   "MANAGE_DATA": "Daten verwalten",

--- a/de/menu.json
+++ b/de/menu.json
@@ -2,6 +2,7 @@
   "cancel": "Abbrechen",
   "continue": "Fortfahren",
   "dailyRun": "Täglicher Run",
+  "runHistory": "Laufhistorie",
   "loadGame": "Spiel laden",
   "newGame": "Neues Spiel",
   "settings": "Einstellungen",

--- a/en/menu-ui-handler.json
+++ b/en/menu-ui-handler.json
@@ -2,7 +2,6 @@
   "GAME_SETTINGS": "Game Settings",
   "ACHIEVEMENTS": "Achievements",
   "STATS": "Stats",
-  "RUN_HISTORY": "Run History",
   "EGG_LIST": "Egg List",
   "EGG_GACHA": "Egg Gacha",
   "MANAGE_DATA": "Manage Data",

--- a/en/menu.json
+++ b/en/menu.json
@@ -2,6 +2,7 @@
   "cancel": "Cancel",
   "continue": "Continue",
   "dailyRun": "Daily Run",
+  "runHistory": "Run History",
   "loadGame": "Load Game",
   "newGame": "New Game",
   "settings": "Settings",

--- a/es-ES/menu-ui-handler.json
+++ b/es-ES/menu-ui-handler.json
@@ -2,7 +2,6 @@
   "GAME_SETTINGS": "Ajustes",
   "ACHIEVEMENTS": "Logros",
   "STATS": "Estadísticas",
-  "RUN_HISTORY": "Historial de partida",
   "EGG_LIST": "Lista de huevos",
   "EGG_GACHA": "Gacha de Huevos",
   "MANAGE_DATA": "Gestionar datos",

--- a/es-ES/menu.json
+++ b/es-ES/menu.json
@@ -2,6 +2,7 @@
   "cancel": "Cancelar",
   "continue": "Continuar",
   "dailyRun": "Reto diario",
+  "runHistory": "Historial de partida",
   "loadGame": "Cargar partida",
   "newGame": "Nueva partida",
   "settings": "Ajustes",

--- a/fr/menu-ui-handler.json
+++ b/fr/menu-ui-handler.json
@@ -2,7 +2,6 @@
   "GAME_SETTINGS": "Paramètres",
   "ACHIEVEMENTS": "Succès",
   "STATS": "Statistiques",
-  "RUN_HISTORY": "Historique",
   "EGG_LIST": "Liste des Œufs",
   "EGG_GACHA": "Gacha-Œufs",
   "MANAGE_DATA": "Mes données",

--- a/fr/menu.json
+++ b/fr/menu.json
@@ -2,6 +2,7 @@
   "cancel": "Annuler",
   "continue": "Continuer",
   "dailyRun": "Défi du jour",
+  "runHistory": "Historique",
   "loadGame": "Charger la partie",
   "newGame": "Nouvelle partie",
   "settings": "Paramètres",

--- a/it/menu-ui-handler.json
+++ b/it/menu-ui-handler.json
@@ -2,7 +2,6 @@
   "GAME_SETTINGS": "Impostazioni",
   "ACHIEVEMENTS": "Obiettivi",
   "STATS": "Statistiche",
-  "RUN_HISTORY": "Run precedenti",
   "EGG_LIST": "Lista uova",
   "EGG_GACHA": "Macchine uova",
   "MANAGE_DATA": "Gestisci dati",

--- a/it/menu.json
+++ b/it/menu.json
@@ -2,6 +2,7 @@
   "cancel": "Annulla",
   "continue": "Continua",
   "dailyRun": "Run giornaliera",
+  "runHistory": "Run precedenti",
   "loadGame": "Carica partita",
   "newGame": "Nuova partita",
   "settings": "Impostazioni",

--- a/ja/menu-ui-handler.json
+++ b/ja/menu-ui-handler.json
@@ -2,7 +2,6 @@
   "GAME_SETTINGS": "設定",
   "ACHIEVEMENTS": "実績",
   "STATS": "統計",
-  "RUN_HISTORY": "ラン歴",
   "EGG_LIST": "タマゴリスト",
   "EGG_GACHA": "タマゴガチャ",
   "MANAGE_DATA": "データ管理",

--- a/ja/menu.json
+++ b/ja/menu.json
@@ -2,6 +2,7 @@
   "cancel": "キャンセル",
   "continue": "つづきから",
   "dailyRun": "日替わりラン",
+  "runHistory": "ラン歴",
   "loadGame": "セーブを読み込む",
   "newGame": "はじめから",
   "settings": "設定",

--- a/ko/menu-ui-handler.json
+++ b/ko/menu-ui-handler.json
@@ -2,7 +2,6 @@
   "GAME_SETTINGS": "게임 설정",
   "ACHIEVEMENTS": "업적",
   "STATS": "통계",
-  "RUN_HISTORY": "플레이 이력",
   "EGG_LIST": "알 목록",
   "EGG_GACHA": "알 뽑기",
   "MANAGE_DATA": "데이터 관리",

--- a/ko/menu.json
+++ b/ko/menu.json
@@ -2,6 +2,7 @@
   "cancel": "취소",
   "continue": "계속하기",
   "dailyRun": "데일리 런",
+  "runHistory": "플레이 이력",
   "loadGame": "불러오기",
   "newGame": "새 게임",
   "settings": "설정",

--- a/pt-BR/menu-ui-handler.json
+++ b/pt-BR/menu-ui-handler.json
@@ -2,7 +2,6 @@
   "GAME_SETTINGS": "Configurações",
   "ACHIEVEMENTS": "Conquistas",
   "STATS": "Estatísticas",
-  "RUN_HISTORY": "Histórico de Jogos",
   "EGG_LIST": "Incubadora",
   "EGG_GACHA": "Gacha de ovos",
   "MANAGE_DATA": "Gerenciar dados",

--- a/pt-BR/menu.json
+++ b/pt-BR/menu.json
@@ -2,6 +2,7 @@
   "cancel": "Cancelar",
   "continue": "Continuar",
   "dailyRun": "Desafio Diário",
+  "runHistory": "Histórico de Jogos",
   "loadGame": "Carregar Jogo",
   "newGame": "Novo Jogo",
   "settings": "Configurações",

--- a/zh-CN/menu-ui-handler.json
+++ b/zh-CN/menu-ui-handler.json
@@ -2,7 +2,6 @@
   "GAME_SETTINGS": "游戏设置",
   "ACHIEVEMENTS": "成就",
   "STATS": "数据统计",
-  "RUN_HISTORY": "历史记录",
   "EGG_LIST": "蛋列表",
   "EGG_GACHA": "扭蛋机",
   "MANAGE_DATA": "管理数据",

--- a/zh-CN/menu.json
+++ b/zh-CN/menu.json
@@ -2,6 +2,7 @@
   "cancel": "取消",
   "continue": "继续",
   "dailyRun": "每日挑战",
+  "runHistory": "历史记录",
   "loadGame": "加载游戏",
   "newGame": "新游戏",
   "settings": "设置",

--- a/zh-TW/menu-ui-handler.json
+++ b/zh-TW/menu-ui-handler.json
@@ -2,7 +2,6 @@
   "GAME_SETTINGS": "遊戲設置",
   "ACHIEVEMENTS": "成就",
   "STATS": "數據",
-  "RUN_HISTORY": "歷史記錄",
   "EGG_LIST": "蛋列表",
   "EGG_GACHA": "扭蛋機",
   "MANAGE_DATA": "管理數據",

--- a/zh-TW/menu.json
+++ b/zh-TW/menu.json
@@ -2,6 +2,7 @@
   "cancel": "取消",
   "continue": "繼續",
   "dailyRun": "每日挑戰",
+  "runHistory": "歷史記錄",
   "loadGame": "加載遊戲",
   "newGame": "新遊戲",
   "settings": "設定",


### PR DESCRIPTION
Moving the "Run History" option from the menu to the title menu, as per PR https://github.com/pagefaultgames/pokerogue/pull/5139.

No new text is required; existing text is moved from menu-ui-handler.json to menu.json.