### PR TITLE
[Move] Add Magic Coat to battler-tags.json

### DIFF
--- a/en/battler-tags.json
+++ b/en/battler-tags.json
@@ -87,5 +87,6 @@
   "powderOnAdd": "{{pokemonNameWithAffix}} is covered in powder!",
   "powderLapse": "When the flame touched the powder\non the Pokémon, it exploded!",
   "grudgeOnAdd": "{{pokemonNameWithAffix}} wants its target to bear a grudge!",
-  "grudgeLapse": "{{pokemonNameWithAffix}} lost all of {{moveName}}’s PP due to the grudge!"
+  "grudgeLapse": "{{pokemonNameWithAffix}} lost all of {{moveName}}’s PP due to the grudge!",
+  "magicCoatOnAdd": "{{pokemonNameWithAffix}} shrouded itself with Magic Coat!"
 }


### PR DESCRIPTION
Magic Coat adds a battler tag which sends a message saying the "[Name] shrouded itself with Magic Coat!"

Related to #108, and needed for https://github.com/pagefaultgames/pokerogue/pull/5225.

The pokecorpus query for the move:
https://abcboy101.github.io/poke-corpus/#q=shrouded+itself&s=xcosif3z0hQzcQ

For convenience, here's the screenshots for the translations from Poke Corpus:
<details><summary>ja / en</summary>
<img src="https://github.com/user-attachments/assets/689816d4-e810-4d9b-80a3-2c19a823f436" />
</details>

<details><summary>fr</summary>
    <img src="https://github.com/user-attachments/assets/1ff57f5e-a219-4080-bef0-bd5ddfea15f8" />
</details>

<details><summary>it</summary>
    <img src="https://github.com/user-attachments/assets/fb52895d-cbcc-4ada-a2e3-01bee6d70a67"/>
</details>
<details><summary>de / es-ES</summary>
<img src="https://github.com/user-attachments/assets/06ee24a3-d35f-4090-94d8-9e9928ec874e"/>
</details>

<details><summary>ko / zh-CN / zh-TW</summary>
<img src="https://github.com/user-attachments/assets/852d7c50-f20f-42c3-82ad-dd966f87f058"/></details>
