### PR TITLE
Update Bouncy Bubble description for full HP drain

### DIFF
--- a/en/move.json
+++ b/en/move.json
@@ -2929,7 +2929,7 @@
   },
   "bouncyBubble": {
     "name": "Bouncy Bubble",
-    "effect": "The user attacks by shooting water bubbles at the target. It then absorbs water and restores its HP by half the damage taken by the target."
+    "effect": "The user attacks by shooting water bubbles at the target. It then absorbs water and restores its HP by the amount of damage taken by the target."
   },
   "buzzyBuzz": {
     "name": "Buzzy Buzz",


### PR DESCRIPTION
Updates English Bouncy Bubble description to reflect changes planned in PR [#5269](https://github.com/pagefaultgames/pokerogue/pull/5269). It heals by 100% of the damage taken by the target rather than half. Other languages will need to be updated too.