### PR TITLE
Option to show forms in dex

### DIFF
--- a/en/pokedex-ui-handler.json
+++ b/en/pokedex-ui-handler.json
@@ -41,6 +41,7 @@
   "scanLabelPassive": "Enter Passive",
   "goFilters": ": Go to filters",
   "toggleDecorations": ": Toggle decorations",
+  "showForms": ": Show Forms",
   "pokemonNumber": "No. ",
   "cycleShiny": ": Shiny",
   "cycleForm": ": Form",


### PR DESCRIPTION
https://github.com/pagefaultgames/pokerogue/pull/5282 introduces an option to show all form icons for a given species in the main page of the dex. This option comes with a button which needs a localized label.