### PR TITLE
Pokédex option in party menu

### DIFF
--- a/en/party-ui-handler.json
+++ b/en/party-ui-handler.json
@@ -1,6 +1,7 @@
 {
   "SEND_OUT": "Send Out",
   "SUMMARY": "Summary",
+  "POKEDEX": "Pokédex",
   "CANCEL": "Cancel",
   "RELEASE": "Release",
   "APPLY": "Apply",


### PR DESCRIPTION
This one had just slipped through. It has to be in this file due to how the logic in the party ui handler works. But it is a duplicate key so it can be just copied and pasted from other files.