### PR TITLE
Add keys for regional form names

### DIFF
--- a/en/pokemon-form.json
+++ b/en/pokemon-form.json
@@ -286,5 +286,11 @@
   "galarDarumakaZen": "Zen Mode",
   "paldeaTaurosCombat": "Combat Breed",
   "paldeaTaurosBlaze": "Blaze Breed",
-  "paldeaTaurosAqua": "Aqua Breed"
+  "paldeaTaurosAqua": "Aqua Breed",
+  "floetteEternalFlower": "Eternal Flower",
+  "ursalunaBloodmoon": "Bloodmoon",
+  "regionalFormALOLA": "Alolan Form",
+  "regionalFormGALAR": "Galarian Form",
+  "regionalFormHISUI": "Hisuian Form",
+  "regionalFormPALDEA": "Paldean Form"
 }

--- a/en/pokemon-info.json
+++ b/en/pokemon-info.json
@@ -36,5 +36,11 @@
     "DARK": "Dark",
     "FAIRY": "Fairy",
     "STELLAR": "Stellar"
-  }
+  },
+  "eternal_floette_expanded": "Eternal Flower Floette",
+  "bloodmoon_ursaluna_expanded": "Bloodmoon Ursaluna",
+  "expandedNameALOLA": "Alolan {{species}}",
+  "expandedNameGALAR": "Galarian {{species}}",
+  "expandedNameHISUI": "Hisuian {{species}}",
+  "expandedNamePALDEA": "Paldean {{species}}"
 }


### PR DESCRIPTION
Adds keys related to [this](https://github.com/pagefaultgames/pokerogue/pull/5294) PR.

Adds the following keys:
- In `pokemon-info.json`:
  - `eternal_floette_expanded`: Proper expanded name for Eternal Flower Floette
  - `bloodmoon_ursaluna_expanded`: Proper expanded name for Bloodmoon Ursaluna
  - `expandedNameALOLA`: Proper expanded name for Alolan forms. Passes `species` parameter, the species name. For example, "expandedNameALOLA" with "Ninetales" set as species would be "Alolan Ninetales" in English.
  - `expandedNameGALAR`, `expandedNameHISUI`, `expandedNamePALDEA`: See above, for Galarian, Hisuian, and Paldean Forms.
- In `pokemon-form.json`:
  - `floetteEternalFlower`: The form name for Eternal Flower Floette
  - `ursalunaBloodmoon`: The form name for Bloodmoon Ursaluna
  - `regionalFormALOLA`: The name for a regional variant from Alola, in English "Alolan Form"
  - `regionalFormGALAR`, `regionalFormHISUI`, `regionalFormPALDEA`: See above, for Galarian, Hisuian, and Paldean Forms.

![image](https://github.com/user-attachments/assets/ea80c972-f936-4368-ba97-0a3f2af00b8f)
![image](https://github.com/user-attachments/assets/4c077145-764e-48b4-bcee-85545ab207d2)

Please see the PR for the main repo for more context on these keys.