### PR TITLE
Organize form name/append form locales better

### DIFF
--- a/en/pokemon-form.json
+++ b/en/pokemon-form.json
@@ -289,8 +289,19 @@
   "paldeaTaurosAqua": "Aqua Breed",
   "floetteEternalFlower": "Eternal Flower",
   "ursalunaBloodmoon": "Bloodmoon",
-  "regionalFormALOLA": "Alolan Form",
-  "regionalFormGALAR": "Galarian Form",
-  "regionalFormHISUI": "Hisuian Form",
-  "regionalFormPALDEA": "Paldean Form"
+  "regionalForm": {
+    "ALOLA": "Alolan Form",
+    "GALAR": "Galarian Form",
+    "HISUI": "Hisuian Form",
+    "PALDEA": "Paldean Form"
+  },
+  "appendForm": {
+    "GENERIC": "{{pokemonName}} ({{formName}})",
+    "ALOLA": "Alolan {{pokemonName}}",
+    "GALAR": "Galarian {{pokemonName}}",
+    "HISUI": "Hisuian {{pokemonName}}",
+    "PALDEA": "Paldean {{pokemonName}}",
+    "ETERNAL": "Eternal Flower {{pokemonName}}",
+    "BLOODMOON": "Bloodmoon {{pokemonName}}"
+  }
 }

--- a/en/pokemon-info.json
+++ b/en/pokemon-info.json
@@ -36,11 +36,5 @@
     "DARK": "Dark",
     "FAIRY": "Fairy",
     "STELLAR": "Stellar"
-  },
-  "eternal_floette_expanded": "Eternal Flower Floette",
-  "bloodmoon_ursaluna_expanded": "Bloodmoon Ursaluna",
-  "expandedNameALOLA": "Alolan {{species}}",
-  "expandedNameGALAR": "Galarian {{species}}",
-  "expandedNameHISUI": "Hisuian {{species}}",
-  "expandedNamePALDEA": "Paldean {{species}}"
+  }
 }


### PR DESCRIPTION
[For this PR again](https://github.com/pagefaultgames/pokerogue/pull/5294) but with a better organized structure.

Essentially what I did was make 2 new sub-entries, arrays, whatever they're called, in `pokemon-form.json`: `regionalForm` and `appendForm`.
`regionalForm` has the names of the regional forms, similar to before, such as "Hisuian Form".

`appendForm` is for getting a mon's full name with its form attached.
For example, "Eternal Flower Floette", "Alolan Ninetales", "Dusk Mane Necrozma", "Hoopa Unbound", etc.
The sub-keys for `appendForm` are, right now, the first word in the Species enum name, before the underscore. So this would be ALOLA for Alolan forms, ETERNAL, BLOODMOON, etc. This _should_ hold up in the future. Right now there's a key for each of the regions with regional forms, as well as Eternal Flower Floette and Bloodmoon Ursaluna.
Every other form falls under `appendForm.GENERIC`. Some time in the future, if we want, we can add mons like Necrozma to this, since the way "full names" are written varies between mons as well as languages.

MOVED KEYS:

| Before | After|
| --- | --- |
| `pokemonForm:regionalFormALOLA` | `pokemonForm:regionalForm.ALOLA` |
| `pokemonForm:regionalFormGALAR` | `pokemonForm:regionalForm.GALAR` |
| `pokemonForm:regionalFormHISUI` | `pokemonForm:regionalForm.HISUI` |
| `pokemonForm:regionalFormPALDEA` | `pokemonForm:regionalForm.PALDEA` |
|---|---|
| `pokemonInfo:expandedNameALOLA` | `pokemonForm:appendForm.ALOLA` |
| `pokemonInfo:expandedNameGALAR` | `pokemonForm:appendForm.GALAR` |
| `pokemonInfo:expandedNameHISUI` | `pokemonForm:appendForm.HISUI` |
| `pokemonInfo:expandedNamePALDEA` | `pokemonForm:appendForm.PALDEA` |
| `pokemonInfo:eternal_floette_expanded` | `pokemonForm:appendForm.ETERNAL` |
| `pokemonInfo:bloodmoon_ursaluna_expanded` | `pokemonForm:appendForm.BLOODMOON` |

NEW KEY: `pokemonForm:appendForm.GENERIC`