### PR TITLE
Add keys for Neutralizing Gas, move NG keys to arena-tag.json

### DIFF
--- a/en/ability-trigger.json
+++ b/en/ability-trigger.json
@@ -56,7 +56,6 @@
   "postSummonDarkAura": "{{pokemonNameWithAffix}} is radiating a Dark Aura!",
   "postSummonFairyAura": "{{pokemonNameWithAffix}} is radiating a Fairy Aura!",
   "postSummonAuraBreak": "{{pokemonNameWithAffix}} reversed all other Pokémon’s auras!",
-  "postSummonNeutralizingGas": "{{pokemonNameWithAffix}}’s Neutralizing Gas filled the area!",
   "postSummonAsOneGlastrier": "{{pokemonNameWithAffix}} has two Abilities!",
   "postSummonAsOneSpectrier": "{{pokemonNameWithAffix}} has two Abilities!",
   "postSummonVesselOfRuin": "{{pokemonNameWithAffix}}’s Vessel of Ruin lowered the {{statName}}\nof all surrounding Pokémon!",

--- a/en/ability-trigger.json
+++ b/en/ability-trigger.json
@@ -56,6 +56,7 @@
   "postSummonDarkAura": "{{pokemonNameWithAffix}} is radiating a Dark Aura!",
   "postSummonFairyAura": "{{pokemonNameWithAffix}} is radiating a Fairy Aura!",
   "postSummonAuraBreak": "{{pokemonNameWithAffix}} reversed all other Pokémon’s auras!",
+  "postSummonNeutralizingGas": "{{pokemonNameWithAffix}}’s Neutralizing Gas filled the area!",
   "postSummonAsOneGlastrier": "{{pokemonNameWithAffix}} has two Abilities!",
   "postSummonAsOneSpectrier": "{{pokemonNameWithAffix}} has two Abilities!",
   "postSummonVesselOfRuin": "{{pokemonNameWithAffix}}’s Vessel of Ruin lowered the {{statName}}\nof all surrounding Pokémon!",

--- a/en/arena-flyout.json
+++ b/en/arena-flyout.json
@@ -14,6 +14,8 @@
   "harshSun": "Harsh Sun",
   "strongWinds": "Strong Winds",
 
+  "neutralizingGas": "Neutralizing Gas",
+
   "misty": "Misty Terrain",
   "electric": "Electric Terrain",
   "grassy": "Grassy Terrain",

--- a/en/arena-tag.json
+++ b/en/arena-tag.json
@@ -65,5 +65,7 @@
   "grassWaterPledgeOnAdd": "A swamp enveloped the field!",
   "grassWaterPledgeOnAddPlayer": "A swamp enveloped your team!",
   "grassWaterPledgeOnAddEnemy": "A swamp enveloped the opposing team!",
-  "fairyLockOnAdd": "No one will be able to run away during the next turn!"
+  "fairyLockOnAdd": "No one will be able to run away during the next turn!",
+  "neutralizingGasOnAdd": "{{pokemonNameWithAffix}}’s Neutralizing Gas filled the area!",
+  "neutralizingGasOnRemove": "The effects of the neutralizing gas wore off!"
 }


### PR DESCRIPTION
Adds a key for neutralizing gas removal and moves the neutralizing gas keys from ability-trigger to arena-tag (The key is still left in ability-trigger to avoid breaking anything, but should be removed once the main repo PR makes it to main). Also adds an arena-flyout key for neutralizing gas.

[Pokecorpus](https://abcboy101.github.io/poke-corpus/#q=neutralizing+gas&s=xcosif3z0hQzcQ)