### PR TITLE
Add move message for Celebrate

### DIFF
--- a/en/move-trigger.json
+++ b/en/move-trigger.json
@@ -79,5 +79,6 @@
   "instructingMove": "{{targetPokemonName}} followed {{userPokemonName}}’s instructions!",
   "lunarDanceRestore" : "{{pokemonName}} became cloaked in mystical moonlight!",
   "stealPositiveStats": "{{pokemonName}} stole {{targetName}}’s boosted stats!",
-  "forceLast": "{{targetPokemonName}}'s move was postponed!"
+  "forceLast": "{{targetPokemonName}}'s move was postponed!",
+  "celebrate": "Congratulations, {{playerName}}!"
 }


### PR DESCRIPTION
Adds move text when the move Celebrate is used. Main PR here: https://github.com/pagefaultgames/pokerogue/pull/5392