### PR TITLE
Add taunt remove key

### DIFF
--- a/en/battler-tags.json
+++ b/en/battler-tags.json
@@ -77,6 +77,7 @@
   "substituteOnRemove": "{{pokemonNameWithAffix}}’s substitute faded!",
   "tormentOnAdd": "{{pokemonNameWithAffix}} was subjected to torment!",
   "tauntOnAdd": "{{pokemonNameWithAffix}} fell for the taunt!",
+  "tauntOnRemove": "{{pokemonNameWithAffix}} shook off the taunt!",
   "imprisonOnAdd": "{{pokemonNameWithAffix}} sealed any moves\nits target shares with it!",
   "autotomizeOnAdd": "{{pokemonNameWithAffix}} became nimble!",
   "syrupBombOnAdd": "{{pokemonNameWithAffix}} got covered in sticky, candy syrup!",


### PR DESCRIPTION
Adds the key for taunt removal - [Poke Corpus](https://abcboy101.github.io/poke-corpus/#q=shook+off+the+taunt&s=QccR7ok)

[Main PR](https://github.com/pagefaultgames/pokerogue/pull/5407)