### PR TITLE
[Ability] Updated Lure Ability descriptions, fixed Unaware description

### DIFF
--- a/en/ability.json
+++ b/en/ability.json
@@ -137,7 +137,7 @@
   },
   "illuminate": {
     "name": "Illuminate",
-    "description": "By illuminating its surroundings, the Pokémon raises the likelihood of meeting wild Pokémon and prevents its accuracy from being lowered."
+    "description": "By illuminating its surroundings, the Pokémon raises the likelihood of double battles and prevents its accuracy from being lowered."
   },
   "trace": {
     "name": "Trace",
@@ -281,7 +281,7 @@
   },
   "arenaTrap": {
     "name": "Arena Trap",
-    "description": "Prevents opposing Pokémon from fleeing."
+    "description": "Prevents opposing Pokémon from fleeing. This Pokémon also raises the likelihood of double battles."
   },
   "vitalSpirit": {
     "name": "Vital Spirit",
@@ -393,7 +393,7 @@
   },
   "noGuard": {
     "name": "No Guard",
-    "description": "The Pokémon employs no-guard tactics to ensure incoming and outgoing attacks always land."
+    "description": "The Pokémon employs no-guard tactics to ensure incoming and outgoing attacks always land. This Pokémon also raises the likelihood of double battles."
   },
   "stall": {
     "name": "Stall",
@@ -433,7 +433,7 @@
   },
   "unaware": {
     "name": "Unaware",
-    "description": "When attacking, the Pokémon ignores the target Pokémon’s stat changes."
+    "description": "This Pokémon ignores the opposing Pokémon’s stat changes."
   },
   "tintedLens": {
     "name": "Tinted Lens",
@@ -1113,7 +1113,7 @@
   },
   "commander": {
     "name": "Commander",
-    "description": "When the Pokémon enters a battle, it goes inside the mouth of an ally Dondozo if one is on the field. The Pokémon then issues commands from there."
+    "description": "Upon entering battle, this Pokémon goes inside an ally Dondozo if one is on the field; then issues commands from there. This Pokémon also raises the likelihood of double battles."
   },
   "electromorphosis": {
     "name": "Electromorphosis",


### PR DESCRIPTION
## Why are you making these changes?
- Lure abilities are basically undocumented in game, this has been pretty requested by long time players.
- Unaware, despite being the official description, is just wrong. Why did they do this? I don't know. It is now accurate.

## Screenshots/Videos

## Checklist
- [ ] I provided **screenshots** proving my additions are properly working and maked this PR as a **Draft** if I have not
- [ ] This PR is related to a PR in the game repo
  - [ ] If yes, added a link to it in this very description
- [ ] I warned Transaltion staff on Discord about the existence of this PR
