### PR TITLE
Add English dialogue for new trainer types

### DIFF
--- a/en/dialogue.json
+++ b/en/dialogue.json
@@ -446,6 +446,81 @@
       "3": "Everybody works for me, so I have nothing to do."
     }
   },
+  "hooligans": {
+    "encounter": {
+      "1": "Hey, hey! We’ll take care of you!",
+      "2": "Hey, hey! A bad one teamed up with another bad one!"
+    },
+    "victory": {
+      "1": "Huh? You’re saying the friendship between us bad dudes isn’t good enough?"
+    }
+  },
+  "musician": {
+    "encounter": {
+      "1": "Hum fiercely! My battle song!\nBattle fiercely! My Pokémon!"
+    },
+    "victory": {
+      "1": "Hmm... I guess strumming instead of tapping would have been best..."
+    }
+  },
+  "pilot": {
+    "encounter": {
+      "1": "My Pokémon is stronger than the wind. It’s my pride and joy!",
+      "2": "Battle flight is ready for takeoff!"
+    },
+    "victory": {
+      "1": "I felt some intense pressure coming from you and your Pokémon!",
+      "2": "Unfortunately... we are forced to land."
+    }
+  },
+  "pokefan": {
+    "encounter": {
+      "1": "I love my Pokémon more than anything!"
+    },
+    "victory": {
+      "1": "You may have beat me in battle, but my love for Pokémon remains unmatched!"
+    }
+  },
+  "pokefan_female": {
+    "encounter": {
+      "1": "I love my Pokémon more than anything!"
+    },
+    "victory": {
+      "1": "You may have beat me in battle, but my love for Pokémon remains unmatched!"
+    }
+  },
+  "rich": {
+    "encounter": {
+      "1": "In my old age, I have had many rich experiences with my Pokémon.\n$Let me share that wealth of experience with you."
+    },
+    "victory": {
+      "1": "Hah! Very well done, young Trainer!"
+    }
+  },
+  "rich_female": {
+    "encounter": {
+      "1": "In my old age, I have had many rich experiences with my Pokémon.\n$Let me share that wealth of experience with you."
+    },
+    "victory": {
+      "1": "Oh, that battle was absolutely splendid!"
+    }
+  },
+  "rich_kid": {
+    "encounter": {
+      "1": "Your Pokémon cannot possibly match up to luster of my own!"
+    },
+    "victory": {
+      "1": "Huh? But I spent so much money making them as gorgeous as possible..."
+    }
+  },
+  "rich_kid_female": {
+    "encounter": {
+      "1": "I just got my Pokémon’s fur groomed. You better not mess them up!"
+    },
+    "victory": {
+      "1": "Oh no, my poor darling Pokémon!"
+    }
+  },
   "archer": {
     "encounter": {
       "1": "Before you go any further, let’s see how you fare against us, Team Rocket!",


### PR DESCRIPTION
This includes English dialogue entries for Hooligans, Musician, and Pilot. Male and female dialogue entries for Poké Fan, Rich, and Rich Kid are also added, but are currently generic text that should eventually be replaced with canon dialogue, but this is just to get them into a visually functional state.

## Related PR
<!--
If this PR is related to a PR in the game repo, added its link here
-->
https://github.com/pagefaultgames/pokerogue/pull/5520

## Screenshots/Videos
<!--
Screenshots/videos proving you additions/edits properly works in the game
-->

<details><summary>Hooligans</summary>

![image](https://github.com/user-attachments/assets/aaee9c4d-0c06-440c-abfe-0c988eb186c1)

</details>

<details><summary>Musician</summary>

![image](https://github.com/user-attachments/assets/dfe26eee-d659-4c75-a3a6-87ae02610ba7)

</details>

<details><summary>Pilot</summary>

![image](https://github.com/user-attachments/assets/5af87a05-b8de-4ae3-928f-ff85b3369872)

</details>

<details><summary>Poké Fan</summary>

![image](https://github.com/user-attachments/assets/3c2992f5-7500-4f5f-81aa-89999e35944d)

</details>

<details><summary>Rich</summary>

![image](https://github.com/user-attachments/assets/8a468c3e-b6aa-468a-adf1-15363de00231)

</details>

<details><summary>Rich Kid</summary>

![image](https://github.com/user-attachments/assets/b9adb6da-c74f-4bbd-81f2-d5060bfe30cc)

</details>

## Checklist
- [x] I provided **screenshots** proving my additions are properly working and maked this PR as a **Draft** if I have not
- [x] This PR is related to a PR in the game repo
  - [x] If yes, added a link to it in this very description
- [x] I warned Transaltion staff on Discord about the existence of this PR
