### PR TITLE
[Move][En] Added message for Smack Down and Thousand Arrows

### DIFF
--- a/en/move-trigger.json
+++ b/en/move-trigger.json
@@ -81,5 +81,6 @@
   "stealPositiveStats": "{{pokemonName}} stole {{targetName}}’s boosted stats!",
   "forceLast": "{{targetPokemonName}}'s move was postponed!",
   "splash": "But nothing happened!",
+  "fallDown": "The {{targetPokemonName}} fell straight down!",
   "celebrate": "Congratulations, {{playerName}}!"
 }


### PR DESCRIPTION
When this move grounds the target, the message created as fallDown should be displayed for the player.

## Related PR
Fix 5027 PR: (https://github.com/pagefaultgames/pokerogue/pull/5536)

Poke Corpus Fall Down message link: https://abcboy101.github.io/poke-corpus/#q=fell+straight+down!&s=e0ZuZVE

## Screenshots/Videos
### Before:

https://github.com/user-attachments/assets/3b12dcba-2f39-481e-a77b-61e11160a393


### After:

https://github.com/user-attachments/assets/2b6decc6-12f1-44f0-a4fd-f11acba99122


## Checklist
- [x] I provided **screenshots** proving my additions are properly working and maked this PR as a **Draft** if I have not
- [x] This PR is related to a PR in the game repo
  - [x] If yes, added a link to it in this very description
- [x] I warned Transaltion staff on Discord about the existence of this PR
