### PR TITLE
Adjust Mystical Rock Description

### DIFF
--- a/de/modifier-type.json
+++ b/de/modifier-type.json
@@ -359,8 +359,7 @@
       "description": "Dieser bizarre Orb fügt seinem Träger im Kampf Verbrennungen zu."
     },
     "MYSTICAL_ROCK": {
-      "name": "Rätselhafter Stein",
-      "description": "Verlängert die Dauer von Wetter, dass durch Attacken oder Fähigkeiten ausgelöst wurde, um 2 Runden pro Stapel."
+      "name": "Rätselhafter Stein"
     },
     "EVOLUTION_TRACKER_GIMMIGHOUL": {
       "name": "Schätze",

--- a/en/modifier-type.json
+++ b/en/modifier-type.json
@@ -240,7 +240,7 @@
     "TOXIC_ORB": { "name": "Toxic Orb", "description": "It’s a bizarre orb that exudes toxins when touched and will badly poison the holder during battle." },
     "FLAME_ORB": { "name": "Flame Orb", "description": "It’s a bizarre orb that gives off heat when touched and will affect the holder with a burn during battle." },
 
-    "MYSTICAL_ROCK": { "name": "Mystical Rock", "description": "Extends the duration of terrain and weather caused by moves or Abilities by 2 turns per stack." },
+    "MYSTICAL_ROCK": { "name": "Mystical Rock", "description": "Extends the duration of terrain and weather caused by the holder's moves or Abilities by 2 turns." },
 
     "EVOLUTION_TRACKER_GIMMIGHOUL": { "name": "Treasures", "description": "This Pokémon loves treasure! Keep collecting treasure and something might happen!"},
 

--- a/es-ES/modifier-type.json
+++ b/es-ES/modifier-type.json
@@ -359,8 +359,7 @@
       "description": "Extraña esfera que causa quemaduras a quien la usa en combate."
     },
     "MYSTICAL_ROCK": {
-      "name": "Roca Mística",
-      "description": "Extiende la duración del terreno y tiempo atmosférico causado por movimientos y habilidades por 2 turnos por cada objeto."
+      "name": "Roca Mística"
     },
     "EVOLUTION_TRACKER_GIMMIGHOUL": {
       "name": "Tesoros",

--- a/fr/modifier-type.json
+++ b/fr/modifier-type.json
@@ -359,8 +359,7 @@
       "description": "Brule son porteur à la fin du tour s’il n’a pas déjà de problème de statut."
     },
     "MYSTICAL_ROCK": {
-      "name": "Roche Mystique",
-      "description": "Augmente de 2 tours par exemplaire la durée de la météo et de champs causés par une capacité ou un talent."
+      "name": "Roche Mystique"
     },
     "EVOLUTION_TRACKER_GIMMIGHOUL": {
       "name": "Trésors",

--- a/ja/modifier-type.json
+++ b/ja/modifier-type.json
@@ -359,8 +359,7 @@
       "description": "触ると 熱をだす 不思議な玉。\n持たせると 戦闘中に やけどの状態に なる。"
     },
     "MYSTICAL_ROCK": {
-      "name": "しんぴないし",
-      "description": "技や 特性で 起こした 天気や フィールドの 間が しんぴないし当たり ２ターン 上がる"
+      "name": "しんぴないし"
     },
     "EVOLUTION_TRACKER_GIMMIGHOUL": {
       "name": "宝物",

--- a/ko/modifier-type.json
+++ b/ko/modifier-type.json
@@ -359,8 +359,7 @@
       "description": "이 도구를 지닌 포켓몬은 턴이 끝나는 시점에 상태이상에 걸리지 않았다면 화상 상태가 된다."
     },
     "MYSTICAL_ROCK": {
-      "name": "신비한바위",
-      "description": "기술이나 특성으로 발생한 날씨, 필드 효과의 지속 시간을 스택 당 2턴 연장한다."
+      "name": "신비한바위"
     },
     "EVOLUTION_TRACKER_GIMMIGHOUL": {
       "name": "보물",

--- a/pt-BR/modifier-type.json
+++ b/pt-BR/modifier-type.json
@@ -359,8 +359,7 @@
       "description": "Uma esfera estranha que aquece quando tocada e queima quem a segurar."
     },
     "MYSTICAL_ROCK": {
-      "name": "Pedra Mística",
-      "description": "Aumenta a duração do terreno e do clima causados por movimentos ou Habilidades em 2 turnos por pilha."
+      "name": "Pedra Mística"
     },
     "EVOLUTION_TRACKER_GIMMIGHOUL": {
       "name": "Tesouros",

--- a/zh-CN/modifier-type.json
+++ b/zh-CN/modifier-type.json
@@ -359,8 +359,7 @@
       "description": "触碰后会放出热量的神奇宝珠。\n携带后，在战斗时会变成灼伤状态。"
     },
     "MYSTICAL_ROCK": {
-      "name": "神秘石块",
-      "description": "每堆叠一次，可将招式或能力造成的\n地形和天气的持续时间延长 2 回合。"
+      "name": "神秘石块"
     },
     "EVOLUTION_TRACKER_GIMMIGHOUL": {
       "name": "宝藏金币",


### PR DESCRIPTION
## Related PR
<!--
If this PR is related to a PR in the game repo, added its link here
-->
Changes: Extends the duration of terrain and weather caused by moves or Abilities by 2 turns ~~per stack~~.
To: Extends the duration of terrain and weather caused by **the holder's** moves or Abilities by 2 turns.

More clear and consistent with other held items.

Deletes description in other languages

## Screenshots/Videos
<!--
Screenshots/videos proving you additions/edits properly works in the game
-->

## Checklist
- [ ] I provided **screenshots** proving my additions are properly working and maked this PR as a **Draft** if I have not
- [ ] This PR is related to a PR in the game repo
  - [ ] If yes, added a link to it in this very description
- [ ] I warned Transaltion staff on Discord about the existence of this PR
