### PR TITLE
[Mystery] Added new text and trainer name for sky battle mystery encounter

### DIFF
--- a/en/mystery-encounters/sky-battle-dialogue.json
+++ b/en/mystery-encounters/sky-battle-dialogue.json
@@ -1,0 +1,30 @@
+{
+  "intro": "An unusual trainer with sky-gear blocks your way!",
+  "intro_dialogue": "Hey! Care for a Sky Battle with a Sky Trainer?",
+  "title": "Sky Battle!",
+  "speaker": "Sky Trainer",
+  "description": "The trainer is waiting for a response…\nShow them your superior Flying pokémon!",
+  "query": "What will you do?",
+  "option": {
+    "1": {
+      "label": "Accept the Battle",
+      "tooltip": "(-) Hard or Tough Battle\n(+) Move Rewards\nIneligeble moves are set to 0 PP. Restored after Battle.",
+      "selected": "Let's Fly!\n"
+    },
+    "2": {
+      "label": "Flaunt Your Flying Pokémon",
+      "tooltip": "(+) Receive a Gift Item",
+      "disabled_tooltip": "You need at least 3 Flying Pokémon on your team to select this.",
+      "selected": "You proudly send out all your Flying Pokémon…$The Trainer is impressed, but disappointed you didn't just battle them."
+    },
+    "3": {
+      "label": "Leave battle",
+      "tooltip": "(-) No Rewards",
+      "selected": "Guess you chicken'd out, huh? You must fly as much as an ostrich."
+     }
+  },
+  "battle_won": "Well, this is a bit disappointing for a Sky Trainer like me…\nYou're no penguin!$In exchange for the valuable lesson,\nallow me to teach one of your Pokémon a Flying Type Move!",
+  "teach_move_prompt": "Select a move to teach a Pokémon.",
+  "confirm_no_teach": "You sure you don’t want to learn one of these great moves?",
+  "outro": "May we meet again, high in the sky!\n"
+}

--- a/en/trainer-names.json
+++ b/en/trainer-names.json
@@ -186,5 +186,7 @@
   "bug_type_superfan": "Bug-Type Superfan",
   "expert_pokemon_breeder": "Expert Pokémon Breeder",
   "future_self_m": "???",
-  "future_self_f": "???"
+  "future_self_f": "???",
+  "sky_trainer_m": "Sky Trainer Michael",
+  "sky_trainer_f": "Sky Trainer Filipa"
 }


### PR DESCRIPTION
The Sky Battle mystery encounter locales.
The text is adapted from Bug-type super-fan and from [pokecorpus](https://abcboy101.github.io/poke-corpus/#q=sky+battle&s=OgD2Bqk)
## Related PR
<!--
If this PR is related to a PR in the game repo, add its link here.
If not, explain both what this PR changes and what it strives to accomplish.
-->
[Sky battle mystery encounter](https://github.com/pagefaultgames/pokerogue/pull/5940)
## Screenshots/Videos
<!--
Post any screenshots/videos showing your additions/edits working properly in the game.
While not strictly required for smaller fixes, any major changes (like adding/removing locale keys) should ideally have proof of actually functioning as intended.
-->

https://github.com/user-attachments/assets/147f117e-72e4-4dc3-9bc2-1196cfbcc861



## Checklist
- [x] I have provided **screenshots** proving my additions are properly working (if necessary).
- [x] I have attached a link to a main repo PR or properly explained my changes as applicable.
- [x] I have notified Translation staff on Discord about the existence of this PR.
