### PR TITLE
[Feat] Add "repeated_ability" key

### DIFF
--- a/en/mystery-encounters/clowning-around-dialogue.json
+++ b/en/mystery-encounters/clowning-around-dialogue.json
@@ -12,6 +12,7 @@
       "selected": "Your pitiful Pokémon are poised for a pathetic performance!",
       "apply_ability_dialogue": "A sensational showcase!\nYour savvy suits a special skill as spoils!",
       "apply_ability_message": "The clown is offering to permanently Skill Swap one of your Pokémon’s ability to {{ability}}!",
+      "repeated_ability": "{{chosenPokemon}} already has the {{ability}} ability. Are you sure you want to apply it?",
       "ability_prompt": "Would you like to permanently teach a Pokémon the {{ability}} ability?",
       "ability_gained": "@s{level_up_fanfare}{{chosenPokemon}} gained the {{ability}} ability!"
     },


### PR DESCRIPTION
to Clowning Around Encounter

## Related PR
https://github.com/pagefaultgames/pokerogue/pull/5288

## Screenshots/V
![image](https://github.com/user-attachments/assets/cdb7058e-9431-4c6b-9400-a7e703573d2f)


## Checklist
- [X] I have provided **screenshots** proving my additions are properly working (if necessary).
- [X] I have attached a link to a main repo PR or properly explained my changes as applicable.
- [X] I have notified Translation staff on Discord about the existence of this PR.
