### PR TITLE
Primeape and Stantler move-use evos

### DIFF
--- a/en/modifier-type.json
+++ b/en/modifier-type.json
@@ -243,6 +243,14 @@
     "MYSTICAL_ROCK": { "name": "Mystical Rock", "description": "Extends the duration of terrain and weather caused by the holder’s moves or Abilities by 2 turns." },
 
     "EVOLUTION_TRACKER_GIMMIGHOUL": { "name": "Treasures", "description": "This Pokémon loves treasure! Keep collecting treasure and something might happen!"},
+    "EVOLUTION_TRACKER_PRIMEAPE": {
+      "name": "Rage Fist",
+      "description": "Primeape evolves when its rage surpasses the limits of its physical form!\nBuild up its rage by using the move Rage Fist!"
+    },
+    "EVOLUTION_TRACKER_STANTLER": {
+      "name": "Psyshield Bash",
+      "description": "Stantler evolves to adapt to harsh environments. Toughen up its defense by using the move Psyshield Bash!"
+    },
 
     "BATON": { "name": "Baton", "description": "Allows passing along effects when switching Pokémon, which also bypasses traps." },
 

--- a/en/pokemon-evolutions.json
+++ b/en/pokemon-evolutions.json
@@ -20,6 +20,7 @@
   "caught": "If {{species}} has been caught",
   "weather": "In certain weather conditions",
   "treasure": "After gathering enough treasure",
+  "moveUseCount": "After using the move {{move}} {{count}} times",
   "nature": "With a certain Nature",
   "biome": "In a certain biome",
   "heldItem": {


### PR DESCRIPTION
## Related PR
<!--
If this PR is related to a PR in the game repo, add its link here.
If not, explain both what this PR changes and what it strives to accomplish.
-->
[Changing Primeape and Stantler evos to using move X times like in the games](<https://github.com/pagefaultgames/pokerogue/pull/5997>)

New keys:
- `pokemonEvolutions:moveUseCount` passes in `move` and `count` parameters
- `modifierType.EVOLUTION_TRACKER_PRIMEAPE`: Rage Fist name, a little flavor for desc. Keep it 5 lines or less.
- `modifierType.EVOLUTION_TRACKER_STANTLER`: Psyshield Bash as name, a little flavor for desc. Keep it 5 lines or less.
## Screenshots/Videos
<!--
Post any screenshots/videos showing your additions/edits working properly in the game.
While not strictly required for smaller fixes, any major changes (like adding/removing locale keys) should ideally have proof of actually functioning as intended.
-->
Screenshots in main PR

## Checklist
- [ ] I have provided **screenshots** proving my additions are properly working (if necessary).
- [ ] I have attached a link to a main repo PR or properly explained my changes as applicable.
- [ ] I have notified Translation staff on Discord about the existence of this PR.
