### PR TITLE
[MOVE] Changed the text displayed when the Sticky Webs move is used to clarify which player is affected

### DIFF
--- a/en/arena-tag.json
+++ b/en/arena-tag.json
@@ -35,7 +35,7 @@
   "toxicSpikesActivateTrapPoison": "{{pokemonNameWithAffix}} absorbed the {{moveName}}!",
   "stealthRockOnAdd": "Pointed stones float in the air\naround {{opponentDesc}}!",
   "stealthRockActivateTrap": "Pointed stones dug into\n{{pokemonNameWithAffix}}!",
-  "stickyWebOnAdd": "A {{moveName}} has been laid out on the ground around the opposing team!",
+  "stickyWebOnAdd": "A {{moveName}} has been laid out on the ground around {{opponentDesc}}!",
   "stickyWebActivateTrap": "The opposing {{pokemonName}} was caught in a sticky web!",
   "trickRoomOnAdd": "{{pokemonNameWithAffix}} twisted\nthe dimensions!",
   "trickRoomOnRemove": "The twisted dimensions\nreturned to normal!",

--- a/es-ES/arena-tag.json
+++ b/es-ES/arena-tag.json
@@ -35,7 +35,6 @@
   "toxicSpikesActivateTrapPoison": "¡{{pokemonNameWithAffix}} ha sido herido por {{moveName}}!",
   "stealthRockOnAdd": "¡El equipo de {{opponentDesc}} ha sido rodeado por piedras puntiagudas!",
   "stealthRockActivateTrap": "¡Unas piedras puntiagudas han dañado\na {{pokemonNameWithAffix}}!",
-  "stickyWebOnAdd": "¡Una {{moveName}} se extiende\na los pies del bando rival!",
   "stickyWebActivateTrap": "¡{{pokemonName}} ha caído en una red viscosa!",
   "trickRoomOnAdd": "¡{{pokemonNameWithAffix}} ha alterado\nlas dimensiones!",
   "trickRoomOnRemove": "Se han restaurado las dimensiones alteradas.",

--- a/fr/arena-tag.json
+++ b/fr/arena-tag.json
@@ -35,7 +35,6 @@
   "toxicSpikesActivateTrapPoison": "{{pokemonNameWithAffix}} absorbe\n{{moveName}} !",
   "stealthRockOnAdd": "Des pierres pointues lévitent\nautour de {{opponentDesc}} !",
   "stealthRockActivateTrap": "Des pierres pointues\ntranspercent {{pokemonNameWithAffix}} !",
-  "stickyWebOnAdd": "Le terrain est couvert d’une {{moveName}}\ndu côté de l’équipe ennemie !",
   "stickyWebActivateTrap": "{{pokemonName}} ennemi\nest pris dans la toile gluante !",
   "trickRoomOnAdd": "{{pokemonNameWithAffix}}\nfausse les dimensions !",
   "trickRoomOnRemove": "Les dimensions faussées\nreviennent à la normale !",

--- a/it/arena-tag.json
+++ b/it/arena-tag.json
@@ -35,7 +35,6 @@
   "toxicSpikesActivateTrapPoison": "{{pokemonNameWithAffix}} assorbe le {{moveName}}!",
   "stealthRockOnAdd": "{{opponentDesc}} è circondata da rocce\naguzze sospese in aria!",
   "stealthRockActivateTrap": "Rocce aguzze colpiscono\n{{pokemonNameWithAffix}}!",
-  "stickyWebOnAdd": "Una {{moveName}} viene stesa ai piedi\ndella squadra avversaria!",
   "stickyWebActivateTrap": "{{pokemonName}} nemico rimane\nimpigliato nella Rete Vischiosa!",
   "trickRoomOnAdd": "{{pokemonNameWithAffix}} crea\nuna dimensione distorta!",
   "trickRoomOnRemove": "La dimensione distorta\ntorna alla normalità!",

--- a/ja/arena-tag.json
+++ b/ja/arena-tag.json
@@ -35,7 +35,6 @@
   "toxicSpikesActivateTrapPoison": "{{pokemonNameWithAffix}}は\n{{moveName}}で　毒を　あびた！",
   "stealthRockOnAdd": "{{opponentDesc}}の　周りに\nとがった岩が　ただよい始めた！",
   "stealthRockActivateTrap": "{{pokemonNameWithAffix}}に\nとがった岩が　食い込んだ！",
-  "stickyWebOnAdd": "相手の　足下に\n{{moveName}}が　広がった！",
   "stickyWebActivateTrap": "相手の　{{pokemonName}}は\nねばねばネットに　ひっかかった！",
   "trickRoomOnAdd": "{{pokemonNameWithAffix}}は\n時空を　ゆがめた！",
   "trickRoomOnRemove": "ゆがんだ　時空が　元に戻った！",

--- a/pt-BR/arena-tag.json
+++ b/pt-BR/arena-tag.json
@@ -35,7 +35,6 @@
   "toxicSpikesActivateTrapPoison": "{{pokemonNameWithAffix}} absorveu os {{moveName}}!",
   "stealthRockOnAdd": "Pedras pontiagudas estão flutuando\nao redor de {{opponentDesc}}!",
   "stealthRockActivateTrap": "{{pokemonNameWithAffix}} foi atingido\npor pedras pontiagudas!",
-  "stickyWebOnAdd": "Uma {{moveName}} foi espalhada no chão ao redor da equipe adversária!",
   "stickyWebActivateTrap": "{{pokemonName}} adversário foi pego por uma Sticky Web!",
   "trickRoomOnAdd": "{{pokemonNameWithAffix}} distorceu\nas dimensões!",
   "trickRoomOnRemove": "As dimensões distorcidas\nretornaram ao normal!",

--- a/zh-CN/arena-tag.json
+++ b/zh-CN/arena-tag.json
@@ -35,7 +35,6 @@
   "toxicSpikesActivateTrapPoison": "{{pokemonNameWithAffix}}\n吸收了{{moveName}}！",
   "stealthRockOnAdd": "{{opponentDesc}}周围\n开始浮现出尖锐的岩石！",
   "stealthRockActivateTrap": "尖锐的岩石扎进了\n{{pokemonNameWithAffix}}的体内！",
-  "stickyWebOnAdd": "对方的脚下\n延伸出了{{moveName}}！",
   "stickyWebActivateTrap": "{{pokemonName}}\n被黏黏网粘住了！",
   "trickRoomOnAdd": "{{pokemonNameWithAffix}}\n扭曲了时空！",
   "trickRoomOnRemove": "扭曲的时空复原了！",

--- a/zh-TW/arena-tag.json
+++ b/zh-TW/arena-tag.json
@@ -35,7 +35,6 @@
   "toxicSpikesActivateTrapPoison": "{{pokemonNameWithAffix}}\n吸收了{{moveName}}！",
   "stealthRockOnAdd": "{{opponentDesc}}周圍\n開始浮現出尖銳的岩石！",
   "stealthRockActivateTrap": "尖銳的岩石紮進了\n{{pokemonNameWithAffix}}的體內！",
-  "stickyWebOnAdd": "對方的腳下\n延伸出了{{moveName}}！",
   "stickyWebActivateTrap": "{{pokemonName}}\n被黏黏網粘住了！",
   "trickRoomOnAdd": "{{pokemonNameWithAffix}}\n扭曲了時空！",
   "trickRoomOnRemove": "扭曲的時空複原了！",


### PR DESCRIPTION
## Related Issue
https://github.com/pagefaultgames/pokerogue/issues/5051

## Why did I make this change
As the issue describes, when either you or the trainer uses Sticky Web, the same text is displayed, which causes confusion. I made it clearer by displaying the name of the Pokémon that is affected.

## Screenshots/Videos
<img width="1512" alt="Bildschirmfoto 2025-06-29 um 22 34 03" src="https://github.com/user-attachments/assets/c5fea5ba-9953-4433-8097-9937ac1c0f9a" />
<img width="1512" alt="Bildschirmfoto 2025-06-29 um 22 34 32" src="https://github.com/user-attachments/assets/b5c970b1-de8d-47d7-8dac-7abea8f7243f" />

## Checklist
- [x] I have provided **screenshots** proving my additions are properly working (if necessary).
- [x] I have attached a link to a main repo PR or properly explained my changes as applicable.
- [x] I have notified Translation staff on Discord about the existence of this PR.
