### PR TITLE
fix typo in key `cancelControllerChoice`

### DIFF
--- a/ca/settings.json
+++ b/ca/settings.json
@@ -106,7 +106,7 @@
   "gamepadSupport": "Suport de Controlador",
   "gamepadSupportAuto": "Automàtic",
   "gamepadSupportDisabled": "Desactivat",
-  "cancelContollerChoice": "Cancel·la",
+  "cancelControllerChoice": "Cancel·la",
   "showBgmBar": "Mostrar Nom de la Cançó",
   "moveTouchControls": "Moure Controls Tàctils",
   "touchReset": "Restablir",

--- a/de/settings.json
+++ b/de/settings.json
@@ -118,7 +118,7 @@
   "pressActionToAssign": "Aktion zum Zuweisen drücken",
   "willSwapWith": "tauscht mit",
   "confirmSwap": "Tausch bestätigen",
-  "cancelContollerChoice": "Abbrechen",
+  "cancelControllerChoice": "Abbrechen",
   "showBgmBar": "Musiknamen anzeigen",
   "hideUsername": "Nutzername verstecken",
   "moveTouchControls": "Bewegung Touch Steuerung",

--- a/en/settings.json
+++ b/en/settings.json
@@ -118,7 +118,7 @@
   "pressActionToAssign": "Press action to assign",
   "willSwapWith": "will swap with",
   "confirmSwap": "Confirm swap",
-  "cancelContollerChoice": "Cancel",
+  "cancelControllerChoice": "Cancel",
   "showBgmBar": "Show Music Names",
   "hideUsername": "Hide Username",
   "moveTouchControls": "Move Touch Controls",

--- a/es-ES/settings.json
+++ b/es-ES/settings.json
@@ -118,7 +118,7 @@
   "pressActionToAssign": "Pulsa el botón de acción para asignar",
   "willSwapWith": "se va a cambiar con",
   "confirmSwap": "Confirmar cambio",
-  "cancelContollerChoice": "Cancelar",
+  "cancelControllerChoice": "Cancelar",
   "showBgmBar": "Mostrar título de canción",
   "moveTouchControls": "Controles táctiles",
   "touchReset": "Restablecer",

--- a/fr/settings.json
+++ b/fr/settings.json
@@ -118,7 +118,7 @@
   "pressActionToAssign": "Bouton Action pour assigner",
   "willSwapWith": "va remplacer",
   "confirmSwap": "Confirmer",
-  "cancelContollerChoice": "Annuler",
+  "cancelControllerChoice": "Annuler",
   "showBgmBar": "Titre de la musique",
   "hideUsername": "Masquer nom d'utilisateur·ice",
   "moveTouchControls": "Déplacer les contrôles tactiles",

--- a/it/settings.json
+++ b/it/settings.json
@@ -118,7 +118,7 @@
   "pressActionToAssign": "Premi il Tasto per assegnare",
   "willSwapWith": "si scambierà con",
   "confirmSwap": "Conferma scambio",
-  "cancelContollerChoice": "Annulla",
+  "cancelControllerChoice": "Annulla",
   "showBgmBar": "Mostra Nomi Musica",
   "hideUsername": "Nascondi Username",
   "moveTouchControls": "Sposta controlli tocco",

--- a/ja/settings.json
+++ b/ja/settings.json
@@ -118,7 +118,7 @@
   "pressActionToAssign": "「決定」キーで割り当てる",
   "willSwapWith": "-->",
   "confirmSwap": "変更を確認",
-  "cancelContollerChoice": "キャンセル",
+  "cancelControllerChoice": "キャンセル",
   "showBgmBar": "BGMの名前を表示",
   "hideUsername": "ユーザー名を非表示",
   "moveTouchControls": "タッチ移動操作",

--- a/ko/settings.json
+++ b/ko/settings.json
@@ -118,7 +118,7 @@
   "pressActionToAssign": "할당을 위해 입력하세요",
   "willSwapWith": "다음 버튼과 교체하시겠습니까?: ",
   "confirmSwap": "교체를 완료했습니다",
-  "cancelContollerChoice": "취소",
+  "cancelControllerChoice": "취소",
   "showBgmBar": "BGM 제목 보여주기",
   "hideUsername": "어버이 익명화",
   "moveTouchControls": "터치 컨트롤 이동",

--- a/pt-BR/settings.json
+++ b/pt-BR/settings.json
@@ -118,7 +118,7 @@
   "pressActionToAssign": "Pressione ação para atribuir",
   "willSwapWith": "trocará com",
   "confirmSwap": "Confirmar troca",
-  "cancelContollerChoice": "Cancelar",
+  "cancelControllerChoice": "Cancelar",
   "showBgmBar": "Exibir Nomes das Músicas",
   "hideUsername": "Ocultar Usuário",
   "moveTouchControls": "Mover Controles de Toque",

--- a/ru/settings.json
+++ b/ru/settings.json
@@ -118,7 +118,7 @@
   "pressActionToAssign": "Нажмите чтобы назначить",
   "willSwapWith": "поменяется с",
   "confirmSwap": "Подтвердить смену",
-  "cancelContollerChoice": "Отмена",
+  "cancelControllerChoice": "Отмена",
   "showBgmBar": "Показать Названия Музыки",
   "moveTouchControls": "Изменить Сенсорное Управление",
   "touchReset": "Сбросить",

--- a/zh-CN/settings.json
+++ b/zh-CN/settings.json
@@ -102,7 +102,7 @@
   "mute": "静音",
   "controller": "控制器",
   "gamepadSupport": "手柄支持",
-  "cancelContollerChoice": "取消",
+  "cancelControllerChoice": "取消",
   "showBgmBar": "显示音乐名称",
   "moveTouchControls": "移动触摸控制",
   "touchReset": "重置",


### PR DESCRIPTION

> [!CAUTION]
> This PR deletes existing keys! Do not merge until the associated main repo PR is ready to be merged!

## Explanation of Changes

Rename `cancelContollerChoice` to `cancelControllerChoice`

- Main repo PR: [[Docs/Misc] Fix typos #6231](https://github.com/pagefaultgames/pokerogue/pull/6231)

## Screenshots/Videos


## Checklist
- [ ] I have provided **screenshots** proving my additions are properly working (if necessary).
- [x] I have attached a link to a main repo PR or properly explained my changes as applicable.
- [x] I have notified Translation staff on Discord about the existence of this PR.
- [x] I have uncommented the appropriate warning message if necessary.
