### PR TITLE
Add failure text for when gravity is in effect.

### DIFF
--- a/en/battle.json
+++ b/en/battle.json
@@ -58,6 +58,7 @@
   "moveDisabledConsecutive": "You can’t use {{moveName}} twice in a row!",
   "moveDisabledBelch": "{{pokemonNameWithAffix}} hasn’t eaten any held Berries, so it can’t possibly belch!",
   "moveDisabledNoBerry": "It can’t use the move because it doesn’t have a Berry!",
+  "moveDisabledGravity": "{{pokemonNameWithAffix}} can’t use {{moveName}} because of gravity!",
   "canOnlyUseMove": "{{pokemonName}} can only use {{moveName}}!",
   "moveCannotBeSelected": "{{moveName}} cannot be selected!",
   "moveCannotUseChallenge": "{{moveName}} cannot be used because of a challenge!",


### PR DESCRIPTION
Exact same reasoning as #219, but I found gravity as another entry needing localization.
Pokecorpus link: https://abcboy101.github.io/poke-corpus/#id=sv.btl_set.BTL_STRID_SET_JyuryokuWazaFail

## Checklist
- [ ] I have provided **screenshots** proving my additions are properly working (if necessary).
- [ ] I have attached a link to a main repo PR or properly explained my changes as applicable.
- [ ] I have notified Translation staff on Discord about the existence of this PR.
- ~~[ ] I have uncommented the appropriate warning message if necessary.~~