### PR TITLE
add locales format workflow script

### DIFF
--- a/.github/scripts/helpers/strings.js
+++ b/.github/scripts/helpers/strings.js
@@ -1,0 +1,179 @@
+// #region Split string code
+// Regexps involved with splitting words in various case formats.
+// Sourced from https://www.npmjs.com/package/change-case (with slight tweaking here and there)
+
+/**
+ * Regex to split at word boundaries.
+ * @type {RegExp}
+ */
+const SPLIT_LOWER_UPPER_RE = /([\p{Ll}\d])(\p{Lu})/gu;
+/**
+ * Regex to split around single-letter uppercase words.
+ * @type {RegExp}
+ */
+const SPLIT_UPPER_UPPER_RE = /(\p{Lu})([\p{Lu}][\p{Ll}])/gu;
+/**
+ * Regexp involved with stripping non-word delimiters from the result.
+ * @type {RegExp}
+ */
+const DELIM_STRIP_REGEXP = /[-_ ]+/giu;
+// The replacement value for splits.
+const SPLIT_REPLACE_VALUE = "$1\0$2";
+
+/**
+ * Split any cased string into an array of its constituent words.
+ * @param {string} value
+ * @returns {string[]} The new string, delimited at each instance of one or more spaces, underscores, hyphens
+ * or lower-to-upper boundaries.
+ */
+function splitWords(value) {
+  let result = value.trim();
+  result = result.replace(SPLIT_LOWER_UPPER_RE, SPLIT_REPLACE_VALUE).replace(SPLIT_UPPER_UPPER_RE, SPLIT_REPLACE_VALUE);
+  result = result.replace(DELIM_STRIP_REGEXP, "\0");
+  // Trim the delimiter from around the output string
+  return trimFromStartAndEnd(result, "\0").split(/\0/g);
+}
+
+/**
+ * Helper function to remove one or more sequences of characters from either end of a string.
+ * @param {string} str - The string to replace
+ * @param {string} charToTrim - The string to remove
+ * @returns {string} The string having been trimmed
+ */
+function trimFromStartAndEnd(str, charToTrim) {
+  let start = 0;
+  let end = str.length;
+  const blockLength = charToTrim.length;
+  while (str.startsWith(charToTrim, start)) {
+    start += blockLength;
+  }
+  if (start - end === blockLength) {
+    // Occurs if the ENTIRE string is made up of charToTrim (at which point we return nothing)
+    return "";
+  }
+  while (str.endsWith(charToTrim, end)) {
+    end -= blockLength;
+  }
+  return str.slice(start, end);
+}
+// #endregion Split String code
+
+/**
+ * Capitalize the first letter of a string.
+ * @example
+ * ```ts
+ * console.log(capitalizeFirstLetter("consectetur adipiscing elit")); // returns "Consectetur adipiscing elit"
+ * ```
+ * @param {string} str - The string whose first letter is to be capitalized
+ * @return {string} The original string with its first letter capitalized.
+ */
+export function capitalizeFirstLetter(str) {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+/**
+ * Helper method to convert a string into `Title Case` (such as one used for console logs).
+ * @example
+ * ```ts
+ * console.log(toTitleCase("lorem ipsum dolor sit amet")); // returns "Lorem Ipsum Dolor Sit Amet"
+ * ```
+ * @param {string} str - The string being converted
+ * @returns {string} The result of converting `str` into title case.
+ */
+export function toTitleCase(str) {
+  return splitWords(str)
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(" ");
+}
+
+/**
+ * Helper method to convert a string into `camelCase` (such as one used for i18n keys).
+ * @example
+ * ```ts
+ * console.log(toCamelCase("BIG_ANGRY_TRAINER")); // returns "bigAngryTrainer"
+ * ```
+ * @param {string} str - The string being converted
+ * @returns {string} The result of converting `str` into camel case.
+ */
+export function toCamelCase(str) {
+  return splitWords(str)
+    .map((word, index) =>
+      index === 0 ? word.toLowerCase() : word.charAt(0).toUpperCase() + word.slice(1).toLowerCase(),
+    )
+    .join("");
+}
+
+/**
+ * Helper method to convert a string into `PascalCase`.
+ * @example
+ * ```ts
+ * console.log(toPascalCase("hi how was your day")); // returns "HiHowWasYourDay"
+ * ```
+ * @param {string} str - The string being converted
+ * @returns {string} The result of converting `str` into pascal case.
+ */
+export function toPascalCase(str) {
+  return splitWords(str)
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join("");
+}
+
+/**
+ * Helper method to convert a string into `kebab-case` (such as one used for filenames).
+ * @example
+ * ```ts
+ * console.log(toKebabCase("not_kebab-caSe String")); // returns "not-kebab-case-string"
+ * ```
+ * @param {string} str - The string being converted
+ * @returns {string} The result of converting `str` into kebab case.
+ */
+export function toKebabCase(str) {
+  return splitWords(str)
+    .map(word => word.toLowerCase())
+    .join("-");
+}
+
+/**
+ * Helper method to convert a string into `snake_case` (such as one used for filenames).
+ * @example
+ * ```ts
+ * console.log(toSnakeCase("not-in snake_CaSe")); // returns "not_in_snake_case"
+ * ```
+ * @param {string} str - The string being converted
+ * @returns {string} The result of converting `str` into snake case.
+ */
+export function toSnakeCase(str) {
+  return splitWords(str)
+    .map(word => word.toLowerCase())
+    .join("_");
+}
+
+/**
+ * Helper method to convert a string into `UPPER_SNAKE_CASE`.
+ * @example
+ * ```ts
+ * console.log(toUpperSnakeCase("apples bananas_oranGes-PearS")); // returns "APPLES_BANANAS_ORANGES_PEARS"
+ * ```
+ * @param {string} str - The string being converted
+ * @returns {string} The result of converting `str` into upper snake case.
+ */
+export function toUpperSnakeCase(str) {
+  return splitWords(str)
+    .map(word => word.toUpperCase())
+    .join("_");
+}
+
+/**
+ * Helper method to convert a string into `Pascal_Snake_Case`.
+ * @example
+ * ```ts
+ * console.log(toPascalSnakeCase("apples-bananas_oranGes Pears")); // returns "Apples_Bananas_Oranges_Pears"
+ * ```
+ * @param {string} str - The string being converted
+ * @returns {string} The result of converting `str` into pascal snake case.
+ */
+export function toPascalSnakeCase(str) {
+  return splitWords(str)
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join("_");
+}

--- a/.github/scripts/locales-format-checker/check-locales.js
+++ b/.github/scripts/locales-format-checker/check-locales.js
@@ -1,0 +1,233 @@
+import * as core from "@actions/core";
+import { existsSync, readFileSync } from "node:fs";
+import {
+  toCamelCase,
+  toKebabCase,
+  toPascalCase,
+  toPascalSnakeCase,
+  toSnakeCase,
+  toUpperSnakeCase,
+} from "../helpers/strings.js";
+import { COLORS, fileNameFormat, i18nextKeyExtensions, keyFormat, LOCALES_DIR } from "./constants.js";
+import { getFiles } from "./get-files.js";
+
+//#region Key Format
+
+/**
+ * Check the key format of all locales files.
+ * @param {options} options - The options to use.
+ * @returns {Promise<incorrectKeys>} The incorrect keys found.
+ */
+export async function checkLocaleKeys(options) {
+  return new Promise(resolve => {
+    /** @type {incorrectKeys} */
+    let incorrectKeys = {};
+
+    for (const languageCode of options.languages) {
+      core.startGroup(`Checking keys for ${languageCode}`);
+      const path = `${LOCALES_DIR}/${languageCode}`;
+      const files = getFiles(path);
+      let languageCodeIncorrectKeys = 0;
+      for (const filePath of files) {
+        const fileIncorrectKeys = checkForIncorrectKeys(filePath, options);
+        if (fileIncorrectKeys !== null) {
+          incorrectKeys = { ...incorrectKeys, ...fileIncorrectKeys };
+          languageCodeIncorrectKeys += Object.values(fileIncorrectKeys).reduce((sum, val) => sum + val.length, 0);
+        }
+      }
+      core.info(
+        `${COLORS.magenta}Checked ${files.length} files for ${languageCode} and found ${languageCodeIncorrectKeys} incorrect keys.`,
+      );
+      core.endGroup();
+    }
+    resolve(incorrectKeys);
+  });
+}
+
+/**
+ * Read a file and return its content.
+ * @param {string} filePath - The path to the file to read.
+ * @returns {string | null} The content of the file.
+ */
+function readFileContent(filePath) {
+  if (!existsSync(filePath)) {
+    return null;
+  }
+  return readFileSync(filePath, "utf8");
+}
+
+/**
+ * Check a file for incorrect keys.
+ * @param {string} filePath - The path to the file to check.
+ * @param {options} options - The options to use.
+ * @returns {incorrectKeys | null} The incorrect keys found in the file.
+ */
+function checkForIncorrectKeys(filePath, options) {
+  /** @type {incorrectKeys} */
+  const incorrectKeys = {};
+  if (options.verbose) {
+    core.info(`${COLORS.file}checking file: ${filePath}`);
+  }
+
+  let data;
+  try {
+    const fileContent = readFileContent(filePath);
+    if (fileContent === null) {
+      return null;
+    }
+    data = JSON.parse(fileContent);
+  } catch (e) {
+    core.setFailed(`Error parsing ${filePath}: ${e.message}`);
+  }
+  const keys = Object.keys(data);
+
+  const entries = keys.map((key, index) => analyzeKey(key, index, options)).filter(e => e !== null);
+
+  if (entries.length > 0) {
+    incorrectKeys[filePath] = entries;
+  }
+
+  if (entries.length === 0 && options.verbose) {
+    core.info(`${COLORS.green}No incorrect keys found in ${filePath}`);
+  } else {
+    if (options.verbose) {
+      core.info(`${COLORS.red}Found ${entries.length} incorrect keys in ${filePath}`);
+    }
+  }
+  return incorrectKeys;
+}
+
+/**
+ * Analyze a key for correctness.
+ * @param {string} key - The key to analyze.
+ * @param {number} index - The index of the key.
+ * @param {options} options - The options to use.
+ * @returns {incorrectKey | null} The incorrect key and its correction or null if the key is correct.
+ */
+function analyzeKey(key, index, options) {
+  const line = index + 2;
+  let correctKey = getCorrectFormat(key, keyFormat);
+  if (key.includes("_")) {
+    correctKey = processExtensions(key);
+  }
+  if (correctKey === key) {
+    return null;
+  }
+  if (options.verbose) {
+    core.info(`${COLORS.red}Incorrect key found at line ${line}: ${key}`);
+  core.info(`${COLORS.corrected}Correct key: ${correctKey}`);
+  }
+  return { incorrectKey: key, correctedKey: correctKey, line: line };
+}
+
+/**
+ * Process i18next key extensions.
+ * @param {string} key - The key to process.
+ * @returns {string} The correct processed key.
+ */
+function processExtensions(key) {
+  let ret;
+  const parts = key.split("_");
+  ret = parts[0];
+  for (const part of parts.slice(1)) {
+    if (i18nextKeyExtensions.includes(`_${part}`)) {
+      ret += `_${part}`;
+    } else {
+      ret += toPascalCase(part);
+    }
+  }
+  return ret;
+}
+
+//#endregion
+
+//#region File Name Format
+
+/**
+ * Check the file name format of all locales files.
+ * @param {options} options - The options to use.
+ * @returns {Promise<incorrectFileNames>} The incorrect file names found.
+ */
+export async function checkLocaleFileNames(options) {
+  return new Promise(resolve => {
+    /** @type {incorrectFileNames} */
+    const incorrectFileNames = {};
+
+    for (const languageCode of options.languages) {
+      core.startGroup(`Checking file names for ${languageCode}`);
+      const path = `${LOCALES_DIR}/${languageCode}`;
+      const files = getFiles(path);
+      let languageCodeIncorrectFiles = 0;
+      const InvalidFileNamesForLang = [];
+      for (const filePath of files) {
+        const fileNameResult = checkForIncorrectFileName(filePath, options);
+        if (fileNameResult !== null) {
+          InvalidFileNamesForLang.push(fileNameResult);
+          languageCodeIncorrectFiles++;
+        }
+      }
+      core.info(
+          `${COLORS.magenta}Checked ${files.length} files for ${languageCode} and found ${languageCodeIncorrectFiles} incorrect file names.`,
+      );
+      if (languageCodeIncorrectFiles > 0) {
+        incorrectFileNames[languageCode] = InvalidFileNamesForLang;
+      }
+      core.endGroup();
+    }
+    resolve(incorrectFileNames);
+  });
+}
+
+/**
+ * Check a file name for incorrect format.
+ * @param {string} filePath - The path to the file to check.
+ * @param {options} options - The options to use.
+ * @returns {incorrectFileName | null} The incorrect file name found.
+ */
+function checkForIncorrectFileName(filePath, options) {
+  if (options.verbose) {
+    core.info(`${COLORS.file}checking file: ${filePath}`);
+  }
+
+  const fileName = filePath.split("/").pop();
+  if (fileName === undefined) {
+    return null;
+  }
+
+  const correctFileName = getCorrectFormat(fileName, fileNameFormat);
+  if (correctFileName === fileName) {
+    return null;
+  }
+  if (options.verbose) {
+    core.info(`${COLORS.red}Incorrect file name found: ${fileName}`);
+    core.info(`${COLORS.corrected}Correct file name: ${correctFileName}`);
+  }
+  return { incorrectFileName: fileName, correctedFileName: correctFileName };
+}
+
+//#endregion
+
+/**
+ * Returns the correct format for the provided format.
+ * @param {string} key - The key to get the correct format for.
+ * @param {format} format - The format to get the correct format for.
+ * @returns {string} The correct format.
+ */
+function getCorrectFormat(key, format) {
+  switch (format) {
+    case "camelCase":
+      return toCamelCase(key);
+    case "kebab-case":
+      return toKebabCase(key);
+    case "PascalCase":
+      return toPascalCase(key);
+    case "snake_case":
+      return toSnakeCase(key);
+    case "UPPER_SNAKE_CASE":
+      return toUpperSnakeCase(key);
+    case "Pascal_Snake_Case":
+      return toPascalSnakeCase(key);
+    default:
+      core.setFailed(`Unknown format: ${format}`);
+  }
+}

--- a/.github/scripts/locales-format-checker/constants.js
+++ b/.github/scripts/locales-format-checker/constants.js
@@ -1,0 +1,60 @@
+/**
+ * The directory containing all locales files.
+ */
+export const LOCALES_DIR = ".";
+/**
+ * A list of files to ignore.
+ * @type {string[]}
+ */
+export const ignoreList = [
+  "package.json",
+  "modifier-type.json", // todo: remove after modifier rework
+  "modifier.json",
+  "modifier-select-ui-handler.json",
+  ".git",
+  ".github",
+  ".gitignore",
+  "node_modules",
+  ".vscode",
+  "README.md",
+  "pnpm-lock.yaml",
+  "scripts",
+  "LICENSE"
+];
+/**
+ * A list of inbuild i18next key extensions which use snake_case instead of camelCase.
+ * @example `AceTrainer_male`
+ * @link https://www.i18next.com/translation-function/context
+ * @returns {string[]}
+ */
+export const i18nextKeyExtensions = ["_male", "_female", "_ordinal", "_one", "_two", "_other", "_few"];
+
+/**
+ * The key format to check for.
+ * @type {format}
+ */
+export const keyFormat = "camelCase";
+
+/**
+ * The file name format to check for.
+ * @type {format}
+ */
+export const fileNameFormat = "kebab-case";
+
+/**
+ * The file extension to check.
+ */
+export const fileExtension = ".json";
+
+/**
+ * 24 bit Color map
+ */
+export const COLORS = {
+  "blue": "\u001b[38;2;0;0;255m",
+  "green": "\u001b[38;2;0;255;0m",
+  "red": "\u001b[38;2;255;0;0m",
+  "magenta": "\u001b[38;2;136;23;152m",
+  "info": "\u001b[38;2;255;165;0m",
+  "file": "\u001b[38;2;128;128;128m",
+  "corrected": "\u001b[38;2;0;150;255m",
+}

--- a/.github/scripts/locales-format-checker/get-files.js
+++ b/.github/scripts/locales-format-checker/get-files.js
@@ -1,0 +1,59 @@
+import * as core from "@actions/core";
+import { existsSync, lstatSync, readdirSync } from "node:fs";
+import { format } from "node:util";
+import { fileExtension, ignoreList, LOCALES_DIR } from "./constants.js";
+
+/**
+ * Gets all files in a directory and subdirectories.
+ * @param {string} dir
+ * @returns {string[]} A list of all files in the directory and subdirectories.
+ */
+export function getFiles(dir) {
+  /**
+   * A list of all files in the directory and subdirectories.
+   * @type {string[]}
+   */
+  const files = [];
+
+  if (lstatSync(dir).isDirectory()) {
+    const entries = readdirSync(dir);
+
+    for (const entry of entries) {
+      const filePath = `${dir}/${entry}`;
+        files.push(...getFiles(filePath));
+      if (filePath.endsWith(fileExtension) && !ignoreList.includes(entry)) {
+        files.push(filePath);
+      }
+    }
+  }
+  return files;
+}
+
+/**
+ * Get a list of all language codes in the locales folder.
+ * @returns {string[]} A list of all language codes.
+ */
+export function getLanguageCodes() {
+  /**
+   * A list of all language codes in the locales folder.
+   * @type {string[]}
+   */
+  const languageCodes = [];
+
+  if (!existsSync(LOCALES_DIR)) {
+    const errStr = format("Locales folder not found: %s", LOCALES_DIR);
+    core.setFailed(errStr);
+    process.exit();
+  } else {
+    const folders = readdirSync(LOCALES_DIR);
+
+    for (const folder of folders) {
+      if (ignoreList.includes(folder)) {
+        continue;
+      }
+      languageCodes.push(folder);
+    }
+  }
+
+  return languageCodes;
+}

--- a/.github/scripts/locales-format-checker/main.js
+++ b/.github/scripts/locales-format-checker/main.js
@@ -1,0 +1,234 @@
+import * as core from "@actions/core"
+import { checkLocaleFileNames, checkLocaleKeys } from "./check-locales.js"
+import { COLORS } from "./constants.js"
+import { getLanguageCodes } from "./get-files.js"
+
+/**
+ * @packageDocumentation
+ * This script will check the key format of locales files
+ * Usage: `pnpm check-locales <options> [languages]`
+ * Example: `pnpm check-locales -k -f en de fr`. This checks the key and file name format of en, de and fr.
+ * If no languages are provided, it will check all languages.
+ */
+
+const version = "1.0.0"
+
+async function main() {
+    core.info(`\u001b[38;2;255;127;80m🍳 Locales format checker v${version}`)
+
+    try {
+        const args = process.argv.slice(2)
+        const options = await parseArgs(args)
+
+        if (!options.checkKeys && !options.checkFileNames) {
+            core.setFailed("✗ Error: No options provided!")
+            showHelpText()
+            return
+        }
+
+        /** @type {incorrectKeys} */
+        let keyOutput = {}
+        /** @type {incorrectFileNames} */
+        let fileNameOutput = {}
+
+        if (options.checkKeys) {
+            core.info(`${COLORS.info}Checking key format...`)
+            keyOutput = await checkLocaleKeys(options)
+        }
+        if (options.checkFileNames) {
+            core.info(`${COLORS.info}Checking file name format...`)
+            fileNameOutput = await checkLocaleFileNames(options)
+        }
+
+        if (options.checkKeys) {
+            await displayKeyResults(keyOutput, options)
+        }
+
+        if (options.checkFileNames) {
+            await displayFileNameResults(fileNameOutput, options)
+        }
+    } catch (error) {
+        core.setFailed(error.message)
+    }
+}
+
+/**
+ * Parse the command line arguments.
+ * @param {string[]} args - The command line arguments
+ * @returns {options}
+ */
+function parseArgs(args) {
+    const optionArgs = args.filter((arg) => arg.startsWith("-"))
+    const languageArgs = args.filter((arg) => !arg.startsWith("-"))
+    /** @type {options} */
+    const options = {
+        checkKeys: false,
+        checkFileNames: false,
+        verbose: false,
+        languages: [],
+    }
+
+    for (const arg of optionArgs) {
+        switch (arg) {
+            case "-k":
+            case "--keys":
+                options.checkKeys = true
+                break
+            case "-f":
+            case "--filenames":
+                options.checkFileNames = true
+                break
+            case "-v":
+            case "--verbose":
+                options.verbose = true
+                break
+            default:
+                core.setFailed(`Unknown option: ${arg}`)
+                showHelpText()
+                process.exit()
+        }
+    }
+
+    const validLanguages = getLanguageCodes()
+    for (const language of languageArgs) {
+        if (!validLanguages.includes(language)) {
+            core.setFailed(`Invalid language: ${language}`)
+            process.exit()
+        }
+        options.languages.push(language)
+    }
+    if (options.languages.length === 0) {
+        // get all languages if none are specified
+        options.languages = getLanguageCodes()
+    }
+    return options
+}
+
+/**
+ * Display the results for the key format check.
+ * @param {incorrectKeys} result - The incorrect keys found.
+ * @param {options} options - The options used.
+ */
+function displayKeyResults(result, options) {
+    core.info(`${COLORS.info}Key Result:`)
+    if (Object.keys(result).length > 0) {
+        core.setFailed("Found incorrect keys")
+        // Log incorrect keys per language
+        for (const languageCode of options.languages) {
+            const incorrectKeysForLang = Object.entries(result).filter(
+                ([path]) => path.includes(`/${languageCode}/`)
+            )
+            const incorrectKeysCount = incorrectKeysForLang.reduce(
+                (sum, [_, val]) => sum + val.length,
+                0
+            )
+            const color = incorrectKeysCount > 0 ? COLORS.red : COLORS.green
+            core.startGroup(`${color}Result for ${languageCode}`)
+            core.info(
+                `${color}${languageCode}: ${incorrectKeysCount} incorrect keys`
+            )
+            // log all incorrect keys for the language
+            displayIncorrectKeys(
+                languageCode,
+                Object.fromEntries(incorrectKeysForLang)
+            )
+            core.endGroup()
+        }
+        const incorrectKeyCount = Object.values(result).reduce(
+            (sum, val) => sum + val.length,
+            0
+        )
+        core.setFailed(
+            `✗ Found ${incorrectKeyCount} incorrect keys in ${options.languages.length} languages.`
+        )
+    } else {
+        core.info(`${COLORS.green}✔ No incorrect keys found!`)
+        process.exitCode = 0
+    }
+}
+
+/**
+ * Display the results for the file name format check.
+ * @param {incorrectFileNames} result - The incorrect keys found.
+ * @param {options} options - The options used.
+ */
+function displayFileNameResults(result, options) {
+    core.info(`${COLORS.info}File Name Result:`)
+    if (Object.keys(result).length > 0) {
+        core.setFailed("Found incorrect file names")
+        // Log incorrect file names per language
+        for (const languageCode of options.languages) {
+            const incorrectFileNamesForLang = result[languageCode]
+            if (!incorrectFileNamesForLang) {
+                continue
+            }
+            const color =
+                incorrectFileNamesForLang.length > 0 ? COLORS.red : COLORS.green
+
+            core.startGroup(`${color}Result for ${languageCode}`)
+            core.info(
+                `${color}${languageCode}: ${incorrectFileNamesForLang.length} incorrect file names`
+            )
+            displayIncorrectFileNames(incorrectFileNamesForLang)
+            core.endGroup()
+        }
+        const incorrectFileNameCount = Object.values(result).reduce(
+            (sum, val) => sum + val.length,
+            0
+        )
+        core.setFailed(
+            `✗ Found ${incorrectFileNameCount} incorrect file names in ${options.languages.length} languages.`
+        )
+    } else {
+        core.info(`${COLORS.green}✔ No incorrect file names found!`)
+        process.exitCode = 0
+    }
+}
+
+/**
+ * Display the incorrect keys for a language.
+ * @param {string} languageCode - The language code.
+ * @param {incorrectKeys} incorrectKeysForLang - The incorrect keys for the language.
+ */
+function displayIncorrectKeys(languageCode, incorrectKeysForLang) {
+    if (Object.keys(incorrectKeysForLang).length <= 0) {
+        return
+    }
+    for (const [filePath, incorrectKeys] of Object.entries(
+        incorrectKeysForLang
+    )) {
+        if (!filePath.includes(`/${languageCode}/`)) {
+            continue
+        }
+        // log the filepath
+        core.info(`${COLORS.file}File: ${filePath}`)
+        for (const incorrectKey of incorrectKeys) {
+            core.info(
+                `${COLORS.red}Incorrect key found at line ${incorrectKey.line}: ${incorrectKey.incorrectKey}`
+            )
+            core.info(
+                `${COLORS.corrected}Correct key: ${incorrectKey.correctedKey}`
+            )
+        }
+    }
+}
+
+/**
+ * Display the incorrect keys for a language.
+ * @param {incorrectFileName[]} incorrectFileNamesForLang - The incorrect file names for the language.
+ */
+function displayIncorrectFileNames(incorrectFileNamesForLang) {
+    if (incorrectFileNamesForLang.length <= 0) {
+        return
+    }
+    for (const incorrectFileName of incorrectFileNamesForLang) {
+        core.info(
+            `${COLORS.red}Incorrect file name: ${incorrectFileName.incorrectFileName}`
+        )
+        core.info(
+            `${COLORS.corrected}Correct file name: ${incorrectFileName.correctedFileName}`
+        )
+    }
+}
+
+main()

--- a/.github/scripts/locales-format-checker/types.js
+++ b/.github/scripts/locales-format-checker/types.js
@@ -1,0 +1,23 @@
+/**
+ * @typedef {{ incorrectKey: string, correctedKey: string, line: number }} incorrectKey
+ */
+
+/**
+ * @typedef {Object.<string, incorrectKey[]>} incorrectKeys
+ */
+
+/**
+ * @typedef {{ checkKeys: boolean, checkFileNames: boolean, verbose: boolean, languages: string[] }} options
+ */
+
+/**
+ * @typedef {{ incorrectFileName: string, correctedFileName: string }} incorrectFileName
+ */
+
+/**
+ * @typedef {Object.<string, incorrectFileName[]} incorrectFileNames
+ */
+
+/**
+ * @typedef {"camelCase" | "kebab-case" | "PascalCase" | "snake_case" | "UPPER_SNAKE_CASE" | "Pascal_Snake_Case"} format
+ */

--- a/.github/workflows/check-locales-format.yml
+++ b/.github/workflows/check-locales-format.yml
@@ -1,0 +1,58 @@
+name: Validate locales formats
+on:
+    # adjust for Pokerogue
+    pull_request:
+        branches:
+            - main
+    push:
+        branches:
+            - main
+
+jobs:
+    validate-locale-keys:
+        name: Validate locale keys
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v5
+
+            - name: Install pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  version: 10
+
+            - name: Set up Node.js
+              uses: actions/setup-node@v4
+              with:
+                node-version: 22.14.0
+                cache: "pnpm"
+            
+            - name: Install Node.js dependencies
+              run: pnpm add @actions/core
+
+            - name: Validate locale keys
+              run: pnpm check-locales-format:keys
+
+    validate-locale-file-names:
+        name: Validate locale file names
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v5
+
+            - name: Install pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  version: 10
+
+            - name: Set up Node.js
+              uses: actions/setup-node@v4
+              with:
+                node-version: 22.14.0
+                cache: "pnpm"
+            
+            - name: Install Node.js dependencies
+              run: pnpm add @actions/core
+
+            - name: Validate locale file names
+              run: pnpm check-locales-format:files

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "pokerogue-locales",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "check-locales-format:keys": "node ./.github/scripts/locales-format-checker/main.js -k -v",
+    "check-locales-format:files": "node ./.github/scripts/locales-format-checker/main.js -f -v"
+  },
+  "optionalDependencies": {
+    "@actions/core": "^1.11.1"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,72 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    optionalDependencies:
+      '@actions/core':
+        specifier: ^1.11.1
+        version: 1.11.1
+
+packages:
+
+  '@actions/core@1.11.1':
+    resolution: {integrity: sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==}
+
+  '@actions/exec@1.1.1':
+    resolution: {integrity: sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==}
+
+  '@actions/http-client@2.2.3':
+    resolution: {integrity: sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==}
+
+  '@actions/io@1.1.3':
+    resolution: {integrity: sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==}
+
+  '@fastify/busboy@2.1.1':
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
+
+  tunnel@0.0.6:
+    resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
+    engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
+
+  undici@5.29.0:
+    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
+    engines: {node: '>=14.0'}
+
+snapshots:
+
+  '@actions/core@1.11.1':
+    dependencies:
+      '@actions/exec': 1.1.1
+      '@actions/http-client': 2.2.3
+    optional: true
+
+  '@actions/exec@1.1.1':
+    dependencies:
+      '@actions/io': 1.1.3
+    optional: true
+
+  '@actions/http-client@2.2.3':
+    dependencies:
+      tunnel: 0.0.6
+      undici: 5.29.0
+    optional: true
+
+  '@actions/io@1.1.3':
+    optional: true
+
+  '@fastify/busboy@2.1.1':
+    optional: true
+
+  tunnel@0.0.6:
+    optional: true
+
+  undici@5.29.0:
+    dependencies:
+      '@fastify/busboy': 2.1.1
+    optional: true


### PR DESCRIPTION
## Explanation of Changes

- Adds a workflow and associated script for it.
- The workflow will check if all the locales keys are in camelCase
- The workflow will check if all files are in kebab-case

> [!IMPORTANT]
> The script works with i18next context/plurals, but only with the following ones. If a new one is used, it has to be added to the array
```ts
export const i18nextKeyExtensions = ["_male", "_female", "_ordinal", "_one", "_two", "_other", "_few"];
```

> [!NOTE]
> The modifier locale files are ignored for now due to the rework 

## Screenshots/Videos

## Checklist
- [ ] I have provided **screenshots** proving my additions are properly working (if necessary).
- [ ] I have notified Translation staff on Discord about the existence of this PR.
