### PR TITLE
Removed duplicate `battle:trainerGo` key from locales

### DIFF
--- a/de/battle.json
+++ b/de/battle.json
@@ -8,7 +8,6 @@
   "playerComeBack": "Komm zurück, {{pokemonName}}!",
   "trainerComeBack": "{{trainerName}} ruft {{pokemonName}} zurück!",
   "playerGo": "Los! {{pokemonName}}!",
-  "trainerGo": "{{trainerName}} sendet {{pokemonName}} raus!",
   "pokemonDraggedOut": "{{pokemonName}} wurde ausgewählt!",
   "switchQuestion": "Möchtest du {{pokemonName}} auswechseln?",
   "trainerDefeated": "{{trainerName}} wurde besiegt!",

--- a/en/battle.json
+++ b/en/battle.json
@@ -8,7 +8,6 @@
   "playerComeBack": "Come back, {{pokemonName}}!",
   "trainerComeBack": "{{trainerName}} withdrew {{pokemonName}}!",
   "playerGo": "Go! {{pokemonName}}!",
-  "trainerGo": "{{trainerName}} sent out {{pokemonName}}!",
   "pokemonDraggedOut": "{{pokemonName}} was dragged out!",
   "switchQuestion": "Will you switch\n{{pokemonName}}?",
   "trainerDefeated": "You defeated\n{{trainerName}}!",

--- a/es-ES/battle.json
+++ b/es-ES/battle.json
@@ -8,7 +8,6 @@
   "playerComeBack": "¡{{pokemonName}}, vuelve!",
   "trainerComeBack": "¡{{trainerName}} retira a {{pokemonName}}\ndel combate!",
   "playerGo": "¡Adelante, {{pokemonName}}!",
-  "trainerGo": "¡{{trainerName}} saca\na {{pokemonName}}!",
   "switchQuestion": "¿Quieres cambiar\nde {{pokemonName}}?",
   "trainerDefeated": "¡Has derrotado a\n{{trainerName}}!",
   "moneyWon": "¡Has ganado {{moneyAmount}} ₽\npor vencer!",

--- a/fr/battle.json
+++ b/fr/battle.json
@@ -8,7 +8,6 @@
   "playerComeBack": "{{pokemonName}} !\nReviens !",
   "trainerComeBack": "{{trainerName}} retire\n{{pokemonName}} !",
   "playerGo": "{{pokemonName}} !\nGo !",
-  "trainerGo": "{{pokemonName}} est envoyé par\n{{trainerName}} !",
   "pokemonDraggedOut": "{{pokemonName}} est trainé\nde force au combat !",
   "switchQuestion": "Voulez-vous changer\n{{pokemonName}} ?",
   "trainerDefeated": "Vous avez battu\n{{trainerName}} !",

--- a/it/battle.json
+++ b/it/battle.json
@@ -8,7 +8,6 @@
   "playerComeBack": "Rientra, {{pokemonName}}!",
   "trainerComeBack": "{{trainerName}} ha ritirato {{pokemonName}}!",
   "playerGo": "Vai! {{pokemonName}}!",
-  "trainerGo": "{{trainerName}} manda in campo {{pokemonName}}!",
   "pokemonDraggedOut": "{{pokemonName}} è trascinato\nnella lotta!",
   "switchQuestion": "Vuoi cambiare\n{{pokemonName}}?",
   "trainerDefeated": "Hai sconfitto\n{{trainerName}}!",

--- a/ja/battle.json
+++ b/ja/battle.json
@@ -8,7 +8,6 @@
   "playerComeBack": "{{pokemonName}}！　戻れ！",
   "trainerComeBack": "{{trainerName}}は\n{{pokemonName}}を　引っ込めた！",
   "playerGo": "ゆけっ！　 {{pokemonName}}！",
-  "trainerGo": "{{trainerName}}は\n{{pokemonName}}を　繰り出した！",
   "pokemonDraggedOut": "{{pokemonName}}は\n戦闘に　引きずりだされた！",
   "switchQuestion": "{{pokemonName}}を\n入れ替えますか？",
   "trainerDefeated": "{{trainerName}}との　勝負に　勝った！",

--- a/ko/battle.json
+++ b/ko/battle.json
@@ -8,7 +8,6 @@
   "playerComeBack": "돌아와, {{pokemonName}}!",
   "trainerComeBack": "{{trainerName}}[[는]] {{pokemonName}}[[를]] 넣어버렸다!",
   "playerGo": "가랏! {{pokemonName}}!",
-  "trainerGo": "{{trainerName}}[[는]] {{pokemonName}}[[를]] 내보냈다!",
   "pokemonDraggedOut": "{{pokemonName}}[[는]] 배틀에 끌려 나왔다!",
   "switchQuestion": "{{pokemonName}}[[를]]\n교체하시겠습니까?",
   "trainerDefeated": "{{trainerName}}[[와]]의\n승부에서 이겼다!",

--- a/pt-BR/battle.json
+++ b/pt-BR/battle.json
@@ -8,7 +8,6 @@
   "playerComeBack": "{{pokemonName}}, retorne!",
   "trainerComeBack": "{{trainerName}} retirou {{pokemonName}} da batalha!",
   "playerGo": "{{pokemonName}}, eu escolho você!",
-  "trainerGo": "{{trainerName}} escolheu {{pokemonName}}!",
   "pokemonDraggedOut": "{{pokemonName}} foi arrastado(a) para fora!",
   "switchQuestion": "Quer trocar\nde {{pokemonName}}?",
   "trainerDefeated": "Você derrotou\n{{trainerName}}!",

--- a/ru/battle.json
+++ b/ru/battle.json
@@ -8,7 +8,6 @@
   "playerComeBack": "{{pokemonName}},\nназад!",
   "trainerComeBack": "{{trainerName}} отзывает\n{{pokemonName}}!",
   "playerGo": "Вперёд!\n{{pokemonName}}!",
-  "trainerGo": "{{trainerName}} отправляет в бой\n{{pokemonName}}!",
   "switchQuestion": "Заменить своего\n{{pokemonName}}?",
   "trainerDefeated": "Игрок победил противника\n{{trainerName}}!",
   "moneyWon": "Ты получаешь {{moneyAmount}} ₽\nза победу!",

--- a/th/battle.json
+++ b/th/battle.json
@@ -8,7 +8,6 @@
   "playerComeBack": "กลับมา,\n{{pokemonName}}!",
   "trainerComeBack": "{{trainerName}} ถอนตัวออก\n{{pokemonName}}!",
   "playerGo": "ไปเลย\n{{pokemonName}}!",
-  "trainerGo": "{{trainerName}} ปล่อย\n{{pokemonName}} ออกมา!",
   "switchQuestion": "คุณจะเปลี่ยน\n{{pokemonName}} ใช่มั้ย?",
   "trainerDefeated": "คุณได้ชนะ\n{{trainerName}}!",
   "moneyWon": "คุณได้รับ\n₽{{moneyAmount}} จากการชนะ!",

--- a/zh-CN/battle.json
+++ b/zh-CN/battle.json
@@ -8,7 +8,6 @@
   "playerComeBack": "回来吧，{{pokemonName}}！",
   "trainerComeBack": "{{trainerName}}收回了{{pokemonName}}！",
   "playerGo": "去吧！{{pokemonName}}！",
-  "trainerGo": "{{trainerName}}派出了\n{{pokemonName}}！",
   "pokemonDraggedOut": "{{pokemonName}}\n被拖进了战斗！",
   "switchQuestion": "要更换\n{{pokemonName}}吗？",
   "trainerDefeated": "你击败了\n{{trainerName}}！",

--- a/zh-TW/battle.json
+++ b/zh-TW/battle.json
@@ -8,7 +8,6 @@
   "playerComeBack": "回來吧，{{pokemonName}}！",
   "trainerComeBack": "{{trainerName}}收回了{{pokemonName}}！",
   "playerGo": "去吧！{{pokemonName}}！",
-  "trainerGo": "{{trainerName}}派出了\n{{pokemonName}}！",
   "pokemonDraggedOut": "{{pokemonName}}\n被拖出來戰鬥了！",
   "switchQuestion": "要更換\n{{pokemonName}}嗎？",
   "trainerDefeated": "你擊敗了\n{{trainerName}}！",


### PR DESCRIPTION
> [!CAUTION]
> This PR deletes existing keys! Do not merge until the associated main repo PR is ready to be merged!

## Explanation of Changes
Long story short, the de-janking of our main repo's switch sequence also means this duplicate key is no longer used anywhere.
I thus removed it.
- [Main repo PR](https://github.com/pagefaultgames/pokerogue/pull/6611)

## Screenshots/Videos
See main repo PR

## Checklist
- [ ] I have provided **screenshots** proving my additions are properly working (if necessary).
- [ ] I have attached a link to a main repo PR or properly explained my changes as applicable.
- [ ] I have notified Translation staff on Discord about the existence of this PR.
- [x] I have uncommented the appropriate warning message if necessary.
