### PR TITLE
Allow for translation of save data related messages

### DIFF
--- a/en/game-data.json
+++ b/en/game-data.json
@@ -4,5 +4,9 @@
   "settings": "Settings",
   "tutorials": "Tutorials",
   "seenDialogues": "Seen Dialogues",
-  "runHistory": "Run History"
+  "runHistory": "Run History",
+  "reloadSaveData": "Your save data is out of date.\nYour data will be re-downloaded from the server…",
+  "reloadSaveDataLocal": "There was an error updating your save data.\nYour data will be re-initialized from local storage…",
+  "saveDataNotFound": "Save data could not be found. If this is a new account, you can safely ignore this message.",
+  "tooManyConnections": "Too many people are trying to connect and the server is overloaded. Please try again later."
 }


### PR DESCRIPTION
## Explanation of Changes
Moving hardcoded text out of the code so it can be translated.
- Main repo pr: https://github.com/pagefaultgames/pokerogue/pull/7231

## Screenshots/Videos
<details><summary>reloadSaveData</summary>

<img width="1231" height="689" alt="image" src="https://github.com/user-attachments/assets/bac5874b-1bb1-4ba5-b5d7-1ac817bfd593" />

</details>
<details><summary>reloadSaveDataLocal</summary>

<img width="1230" height="688" alt="image" src="https://github.com/user-attachments/assets/65186eb3-d97a-42cc-9c73-81f8cd16636a" />

</details>
<details><summary>saveDataNotFound</summary>

<img width="1231" height="687" alt="image" src="https://github.com/user-attachments/assets/15f81ebd-5018-499e-8077-4c12b812b3b2" />

</details>
<details><summary>tooManyConnections</summary>

<img width="1230" height="684" alt="image" src="https://github.com/user-attachments/assets/5dc25f97-302d-479e-bb06-3e582790a49e" />

</details>

## Checklist
- [x] I have provided **screenshots** proving my additions are properly working (if necessary).
- [x] I have attached a link to a main repo PR or properly explained my changes as applicable.
- [x] I have notified Translation staff on Discord about the existence of this PR.
- ~[ ] I have uncommented the appropriate warning message if necessary.~
