### PR TITLE
Add reminder to PR template to delete keys for re-translation if needed

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,5 +33,5 @@ While not strictly required for smaller fixes, any major changes (like adding/re
 - [ ] I have notified Translation staff on Discord about the existence of this PR.
 - [ ] I have uncommented the appropriate warning message if necessary.
 
-### If the PR includes changes to the text of existing English keys
+### If the PR includes changes to the text of existing English keys:
 - [ ] I have deleted the key from non-English language files so that it can be re-translated.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,3 +32,6 @@ While not strictly required for smaller fixes, any major changes (like adding/re
 - [ ] I have attached a link to a main repo PR or properly explained my changes as applicable.
 - [ ] I have notified Translation staff on Discord about the existence of this PR.
 - [ ] I have uncommented the appropriate warning message if necessary.
+
+### If the PR includes changes to the text of existing English keys
+- [ ] I have deleted the key from non-English language files so that it can be re-translated.


### PR DESCRIPTION
Updated the PR template so it has a reminder that keys in non-English files need to be deleted when English text is changed so that it can be re-translated.