### PR TITLE
Replace Island BGM name

### DIFF
--- a/de/bgm-name.json
+++ b/de/bgm-name.json
@@ -119,7 +119,6 @@
   "grass": "PMD Erkundungsteam Himmel Apfelwald",
   "graveyard": "Firel - Faller",
   "iceCave": "Firel - -50°C",
-  "island": "PMD Erkundungsteam Himmel Schroffküste",
   "jungle": "Lmz - Jungle",
   "laboratory": "Firel - Laboratory",
   "lake": "Lmz - Lake",

--- a/en/bgm-name.json
+++ b/en/bgm-name.json
@@ -120,7 +120,7 @@
   "grass": "PMD EoS Apple Woods",
   "graveyard": "Firel - Faller",
   "iceCave": "Firel - -50°C",
-  "island": "PMD EoS Craggy Coast",
+  "island": "MattCello - Sun Kissed Shore Up",
   "jungle": "Lmz - Jungle",
   "laboratory": "Firel - Laboratory",
   "lake": "Lmz - Lake",

--- a/es-ES/bgm-name.json
+++ b/es-ES/bgm-name.json
@@ -119,7 +119,6 @@
   "grass": "PMD EoS - Manzanar",
   "graveyard": "Firel - Faller",
   "iceCave": "Firel - -50°C",
-  "island": "PMD EoS - Costa Escarpada",
   "jungle": "Lmz - Jungla",
   "laboratory": "Firel - Laboratorio",
   "lake": "Lmz - Lake",

--- a/fr/bgm-name.json
+++ b/fr/bgm-name.json
@@ -119,7 +119,6 @@
   "grass": "PDM EdC - Bois aux Pommes",
   "graveyard": "Firel - Faller",
   "iceCave": "Firel - -50°C",
-  "island": "PDM EdC - Côte Escarpée",
   "jungle": "Lmz - Jungle",
   "laboratory": "Firel - Laboratory",
   "lake": "Lmz - Lake",

--- a/it/bgm-name.json
+++ b/it/bgm-name.json
@@ -116,7 +116,6 @@
   "grass": "PMD EdC - Giardino dei Meli",
   "graveyard": "Firel - Faller",
   "iceCave": "Firel - -50°C",
-  "island": "PMD EdC - Dirupo Costiero",
   "jungle": "Lmz - Jungle",
   "laboratory": "Firel - Laboratorio",
   "lake": "Lmz - Lake",

--- a/ja/bgm-name.json
+++ b/ja/bgm-name.json
@@ -119,7 +119,6 @@
   "grass": "ポケダン空 リンゴのもり",
   "graveyard": "Firel - Faller (落ちる者)",
   "iceCave": "Firel - -50°C",
-  "island": "ポケダン空 えんがんのいわば",
   "jungle": "Lmz - Jungle (ジャングル)",
   "laboratory": "Firel - Laboratory (ラボラトリー)",
   "lake": "Lmz - Lake (湖)",

--- a/ko/bgm-name.json
+++ b/ko/bgm-name.json
@@ -119,7 +119,6 @@
   "grass": "불가사의 던전 하늘의 탐험대 사과의 숲",
   "graveyard": "Firel - Faller",
   "iceCave": "Firel - -50°C",
-  "island": "불가사의 던전 하늘의 탐험대 연안의 암반",
   "jungle": "Lmz - 정글",
   "laboratory": "Firel - 연구소",
   "lake": "Lmz - 호수",

--- a/pt-BR/bgm-name.json
+++ b/pt-BR/bgm-name.json
@@ -119,7 +119,6 @@
   "grass": "PMD EoS Apple Woods",
   "graveyard": "Firel - Faller",
   "iceCave": "Firel - -50°C",
-  "island": "PMD EoS Craggy Coast",
   "jungle": "Lmz - Jungle",
   "laboratory": "Firel - Laboratory",
   "lake": "Lmz - Lake",

--- a/sv/bgm-name.json
+++ b/sv/bgm-name.json
@@ -119,7 +119,6 @@
   "grass": "PMD EoS Apple Woods",
   "graveyard": "Firel - Faller",
   "iceCave": "Firel - -50°C",
-  "island": "PMD EoS Craggy Coast",
   "jungle": "Lmz - Jungle",
   "laboratory": "Firel - Laboratory",
   "lake": "Lmz - Lake",

--- a/tl/bgm-name.json
+++ b/tl/bgm-name.json
@@ -116,7 +116,6 @@
   "grass": "PMD EoS Kakahuyan Ng Mansanas",
   "graveyard": "Firel - Faller",
   "iceCave": "Firel - -50°C",
-  "island": "PMD EoS Mabaatong Baybayin",
   "jungle": "Lmz - Gubat",
   "laboratory": "Firel - Laboratoryo",
   "lake": "Lmz - Lawa",

--- a/uk/bgm-name.json
+++ b/uk/bgm-name.json
@@ -116,7 +116,6 @@
   "grass": "PMD EoS Apple Woods",
   "graveyard": "Firel - Faller",
   "iceCave": "Firel - -50°C",
-  "island": "PMD EoS Craggy Coast",
   "jungle": "Lmz - Jungle",
   "laboratory": "Firel - Laboratory",
   "lake": "Lmz - Lake",

--- a/zh-Hans/bgm-name.json
+++ b/zh-Hans/bgm-name.json
@@ -114,7 +114,6 @@
   "grass": "空之探险队「苹果森林」",
   "graveyard": "Firel - Faller",
   "iceCave": "Firel - -50°C",
-  "island": "空之探险队「沿岸岩地」",
   "jungle": "Lmz - 丛林",
   "laboratory": "Firel - 研究所",
   "lake": "Lmz - 湖泊",

--- a/zh-Hant/bgm-name.json
+++ b/zh-Hant/bgm-name.json
@@ -114,7 +114,6 @@
   "grass": "空之探險隊「蘋果森林」",
   "graveyard": "Firel - Faller",
   "iceCave": "Firel - -50°C",
-  "island": "空之探險隊「沿岸岩地」",
   "jungle": "Lmz - 叢林",
   "laboratory": "Firel - 研究所",
   "lake": "Lmz - Lake",


### PR DESCRIPTION
<!--
If your PR modifies or deletes existing keys that are currently in use,
make sure to uncomment the appropriate notification message below!
-->

> [!WARNING]
> This PR modifies existing keys! Be careful when merging!

<!--
> [!CAUTION]
> This PR deletes existing keys! Do not merge until the associated main repo PR is ready to be merged!
-->

## Explanation of Changes
<!--
If this PR is related to a PR in the game repo, add its link here.
If not, explain both what this PR changes and what it strives to accomplish.
-->
- Main repo PR: N/A
No main repo PR, but there is an assets PR: https://github.com/pagefaultgames/pokerogue-assets/pull/80

Replaced the Island BGM name for the new custom track made by MattCello.

Also deleted all non-English keys for re-translation.

## Screenshots/Videos
<!--
Post any screenshots/videos showing your additions/edits working properly in the game if they are not already in an associated main repo PR.

While not strictly required for smaller fixes, any major changes (like adding/removing locale keys) should ideally have proof of actually functioning as intended.
-->

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e8068f48-3e71-425c-9055-e7aeeb7fde1a" />

## Checklist
- [x] I have provided **screenshots** proving my additions are properly working (if necessary).
- [-] I have attached a link to a main repo PR or properly explained my changes as applicable.
- [x] I have notified Translation staff on Discord about the existence of this PR.
- [x] I have uncommented the appropriate warning message if necessary.
