### PR TITLE
Add message for NPC trainers sending out multiple Pokemon in doubles

### DIFF
--- a/en/battle.json
+++ b/en/battle.json
@@ -3,6 +3,7 @@
   "trainerAppeared": "{{trainerName}}\nwould like to battle!",
   "trainerAppearedDouble": "{{trainerName}}\nwould like to battle!",
   "trainerSendOut": "{{trainerName}} sent out\n{{pokemonName}}!",
+  "trainerSendOutDoubles": "{{trainerName}} sent out\n{{pokemonName1}} and {{pokemonName2}}!",
   "singleWildAppeared": "A wild {{pokemonName}} appeared!",
   "multiWildAppeared": "A wild {{pokemonName1}}\nand {{pokemonName2}} appeared!",
   "playerComeBack": "Come back, {{pokemonName}}!",


### PR DESCRIPTION
## Explanation of Changes
In mainline, when a doubles battle starts vs a trainer the message for when the trainer sends out their pokemon will be combined into "Trainer sent out Pokemon1 and Pokemon2!". This PR adds that message.
- Main repo PR: No PR yet, in progress

## Screenshots/Videos
<details><summary>Mainline message</summary>

<img width="888" height="149" alt="image" src="https://github.com/user-attachments/assets/6259f570-9597-49ff-8772-e7c9cf4d4568" />

</details>
<details><summary>PR message in-game example</summary>

<img width="723" height="177" alt="image" src="https://github.com/user-attachments/assets/bbae20bb-6b59-48d4-a96d-ac6f8f7d6e9c" />

</details> 

## Checklist
- [x] I have provided **screenshots** proving my additions are properly working (if necessary).
- [x] I have attached a link to a main repo PR or properly explained my changes as applicable.
- [x] I have notified Translation staff on Discord about the existence of this PR.
- ~[ ] I have uncommented the appropriate warning message if necessary.~
