### PR TITLE
Add key for pair NPC trainers sending out Pokemon

### DIFF
--- a/en/battle.json
+++ b/en/battle.json
@@ -4,6 +4,7 @@
   "trainerAppearedDouble": "{{trainerName}}\nwould like to battle!",
   "trainerSendOut": "{{trainerName}} sent out\n{{pokemonName}}!",
   "trainerSendOutDoubles": "{{trainerName}} sent out\n{{pokemonName1}} and {{pokemonName2}}!",
+  "pairTrainerSendOutDoubles": "{{trainerName}} sent out\n{{pokemonName1}} and {{pokemonName2}}!",
   "singleWildAppeared": "A wild {{pokemonName}} appeared!",
   "multiWildAppeared": "A wild {{pokemonName1}}\nand {{pokemonName2}} appeared!",
   "playerComeBack": "Come back, {{pokemonName}}!",


### PR DESCRIPTION
## Explanation of Changes
Follow up to #313 to add a key for when the NPC trainer is multiple trainers (e.g. "Tate and Liza"), due to some languages having differences in that case.
- Main repo PR: N/A

## Screenshots/Videos
N/A

## Checklist
- ~[ ] I have provided **screenshots** proving my additions are properly working (if necessary).~
- [x] I have attached a link to a main repo PR or properly explained my changes as applicable.
- [x] I have notified Translation staff on Discord about the existence of this PR.
- ~[ ] I have uncommented the appropriate warning message if necessary.~
