### PR TITLE
Re-add Battle Bond append text with different key

### DIFF
--- a/de/pokemon-form.json
+++ b/de/pokemon-form.json
@@ -306,7 +306,8 @@
     "hisui": "Hisui-{{pokemonName}}",
     "paldea": "Paldea-{{pokemonName}}",
     "eternal": "{{pokemonName}} (Ewigblütler)",
-    "bloodmoon": "Blutmond-{{pokemonName}}"
+    "bloodmoon": "Blutmond-{{pokemonName}}",
+    "battle": "Freundschaftsakt {{pokemonName}}"
   },
   "battleForm": {
     "mega": "Mega",

--- a/en/pokemon-form.json
+++ b/en/pokemon-form.json
@@ -306,7 +306,8 @@
     "hisui": "Hisuian {{pokemonName}}",
     "paldea": "Paldean {{pokemonName}}",
     "eternal": "Eternal Flower {{pokemonName}}",
-    "bloodmoon": "Bloodmoon {{pokemonName}}"
+    "bloodmoon": "Bloodmoon {{pokemonName}}",
+    "battle": "Battle Bond {{pokemonName}}"
   },
   "battleForm": {
     "mega": "Mega",

--- a/es-ES/pokemon-form.json
+++ b/es-ES/pokemon-form.json
@@ -306,7 +306,8 @@
     "hisui": "{{pokemonName}} de Hisui",
     "paldea": "{{pokemonName}} de Paldea",
     "eternal": "{{pokemonName}} Flor Eterna",
-    "bloodmoon": "{{pokemonName}} Luna Carmesí"
+    "bloodmoon": "{{pokemonName}} Luna Carmesí",
+    "battle": "{{pokemonName}} Fuerte Afecto"
   },
   "battleForm": {
     "mega": "Mega",

--- a/fr/pokemon-form.json
+++ b/fr/pokemon-form.json
@@ -306,7 +306,8 @@
     "hisui": "{{pokemonName}} de Hisui",
     "paldea": "{{pokemonName}} de Paldea",
     "eternal": "{{pokemonName}} Fleur Éternelle",
-    "bloodmoon": "{{pokemonName}} Lune Vermeille"
+    "bloodmoon": "{{pokemonName}} Lune Vermeille",
+    "battle": "{{pokemonName}} Synergie"
   },
   "battleForm": {
     "mega": "Méga",

--- a/it/pokemon-form.json
+++ b/it/pokemon-form.json
@@ -306,7 +306,8 @@
     "hisui": "{{pokemonName}} di Hisui",
     "paldea": "{{pokemonName}} di Paldea",
     "eternal": "{{pokemonName}} Fiore Eterno",
-    "bloodmoon": "{{pokemonName}} Luna Cremisi"
+    "bloodmoon": "{{pokemonName}} Luna Cremisi",
+    "battle": "{{pokemonName}} Morfosintonia"
   },
   "battleForm": {
     "mega": "Mega",

--- a/ja/pokemon-form.json
+++ b/ja/pokemon-form.json
@@ -306,7 +306,8 @@
     "hisui": "ヒスイの{{pokemonName}}",
     "paldea": "パルデアの{{pokemonName}}",
     "eternal": "{{pokemonName}}・えいえんのはな",
-    "bloodmoon": "{{pokemonName}}・アカツキ"
+    "bloodmoon": "{{pokemonName}}・アカツキ",
+    "battle": "きずなへんげの{{pokemonName}}"
   },
   "battleForm": {
     "mega": "メガ",

--- a/ko/pokemon-form.json
+++ b/ko/pokemon-form.json
@@ -306,7 +306,8 @@
     "hisui": "히스이 {{pokemonName}}",
     "paldea": "팔데아 {{pokemonName}}",
     "eternal": "영원의 꽃 {{pokemonName}}",
-    "bloodmoon": "붉은 달 {{pokemonName}}"
+    "bloodmoon": "붉은 달 {{pokemonName}}",
+    "battle": "유대변화 {{pokemonName}}"
   },
   "battleForm": {
     "mega": "메가진화",


### PR DESCRIPTION
<!--
If your PR modifies or deletes existing keys that are currently in use,
make sure to uncomment the appropriate notification message below!
-->

<!--
> [!WARNING]
> This PR modifies existing keys! Be careful when merging!
-->

<!--
> [!CAUTION]
> This PR deletes existing keys! Do not merge until the associated main repo PR is ready to be merged!
-->

## Explanation of Changes
<!--
If this PR is related to a PR in the game repo, add its link here.
If not, explain both what this PR changes and what it strives to accomplish.
-->
- Main repo PR: N/A

My earlier PR #333 removed the Battle Bond append key as it didn't appear correctly on the starter select and Pokedex. However, it had been reported that the egg hatch screen's text for Battle Bond Greninja was broken, as it was expecting the append key `"battle"` (it wouldn't have worked correctly before anyways, as the previous key was `"battleBond"`).

As such, this PR restores the key with the now-correct key text and all previous translations for it.

## Screenshots/Videos
<!--
Post any screenshots/videos showing your additions/edits working properly in the game if they are not already in an associated main repo PR.

While not strictly required for smaller fixes, any major changes (like adding/removing locale keys) should ideally have proof of actually functioning as intended.
-->

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3cd2eb79-051d-46ff-a57c-dc4c98ea5502" />

## Checklist
- [x] I have provided **screenshots** proving my additions are properly working (if necessary).
- [x] I have attached a link to a main repo PR or properly explained my changes as applicable.
- [x] I have notified Translation staff on Discord about the existence of this PR.
- [-] I have uncommented the appropriate warning message if necessary.
