### PR TITLE
Update Brazilian Portuguese move effects

### DIFF
--- a/pt-BR/move.json
+++ b/pt-BR/move.json
@@ -4,29 +4,36 @@
     "effect": "O alvo é golpeado com uma pata, uma cauda longa, ou com algo desse tipo."
   },
   "karateChop": {
-    "name": "Karate Chop"
+    "name": "Karate Chop",
+    "effect": "O alvo é atacado com um golpe cortante. A taxa de golpe crítico deste movimento é aumentada em 1 estágio."
   },
   "doubleSlap": {
-    "name": "Double Slap"
+    "name": "Double Slap",
+    "effect": "O alvo é golpeado repetidamente, para frente e para trás, de duas a cinco vezes seguidas."
   },
   "cometPunch": {
-    "name": "Comet Punch"
+    "name": "Comet Punch",
+    "effect": "O alvo é atingido por uma saraivada de socos que golpeiam de duas a cinco vezes seguidas."
   },
   "megaPunch": {
     "name": "Mega Punch",
     "effect": "O alvo é atingido por um soco desferido com grande força muscular."
   },
   "payDay": {
-    "name": "Pay Day"
+    "name": "Pay Day",
+    "effect": "Moedas são arremessadas no alvo para causar dano. Se o alvo for atingido com sucesso, você ganhará dinheiro após a batalha."
   },
   "firePunch": {
-    "name": "Fire Punch"
+    "name": "Fire Punch",
+    "effect": "O alvo é atacado com um soco flamejante. Este movimento tem 10% de chance de causar queimadura no alvo."
   },
   "icePunch": {
-    "name": "Ice Punch"
+    "name": "Ice Punch",
+    "effect": "O alvo é atacado com um soco gelado. Este movimento tem 10% de chance de congelar o alvo."
   },
   "thunderPunch": {
-    "name": "Thunder Punch"
+    "name": "Thunder Punch",
+    "effect": "O alvo é atacado com um soco eletrificado. Este movimento tem 10% de chance de paralisar o alvo."
   },
   "scratch": {
     "name": "Scratch",
@@ -37,32 +44,40 @@
     "effect": "O alvo é agarrado e espremido de ambos os lados para causar dano."
   },
   "guillotine": {
-    "name": "Guillotine"
+    "name": "Guillotine",
+    "effect": "Um ataque cruel e dilacerante com grandes pinças. O alvo desmaia instantaneamente se este ataque acertar, a menos que seja um Pokémon Chefe. A precisão deste movimento é fixada em 30%."
   },
   "razorWind": {
-    "name": "Razor Wind"
+    "name": "Razor Wind",
+    "effect": "O usuário ataca no turno seguinte ao uso deste movimento com lâminas de vento. A taxa de golpe crítico deste movimento é aumentada em 1 estágio."
   },
   "swordsDance": {
-    "name": "Swords Dance"
+    "name": "Swords Dance",
+    "effect": "Uma dança frenética que eleva o espírito de luta. Isso aumenta bruscamente o atributo de Ataque do usuário."
   },
   "cut": {
-    "name": "Cut"
+    "name": "Cut",
+    "effect": "O alvo é cortado com uma foice, uma garra ou algo do tipo para causar dano."
   },
   "gust": {
-    "name": "Gust"
+    "name": "Gust",
+    "effect": "Uma rajada de vento é levantada por asas e lançada no alvo para causar dano. Este movimento pode atingir um alvo que esteja no ar por Fly, Bounce ou Sky Drop com o dobro do poder."
   },
   "wingAttack": {
     "name": "Wing Attack",
     "effect": "O alvo é atingido por asas grandes e imponentes, amplamente abertas para causar dano."
   },
   "whirlwind": {
-    "name": "Whirlwind"
+    "name": "Whirlwind",
+    "effect": "O usuário se move por último e cria um vento forte. O alvo é levado para longe e um Pokémon diferente é arrastado para a batalha. Em batalhas selvagens, isso encerra a batalha contra um único Pokémon."
   },
   "fly": {
-    "name": "Fly"
+    "name": "Fly",
+    "effect": "O usuário voa alto no céu no primeiro turno e ataca no turno seguinte."
   },
   "bind": {
-    "name": "Bind"
+    "name": "Bind",
+    "effect": "Um corpo longo, tentáculos ou algo parecido são usados para prender e apertar o alvo. Por 4 a 5 turnos, o alvo recebe dano igual a um oitavo de seus PS máximos ao final de cada turno."
   },
   "slam": {
     "name": "Slam",
@@ -73,83 +88,104 @@
     "effect": "O usuário utiliza-se de vinhas finas como chicote para infligir dano."
   },
   "stomp": {
-    "name": "Stomp"
+    "name": "Stomp",
+    "effect": "O usuário ataca pisoteando o alvo com um pé grande. Este movimento tem 30% de chance de fazer o alvo hesitar. Se o alvo tiver usado Minimize, o poder deste movimento é duplicado e ele sempre acertará."
   },
   "doubleKick": {
-    "name": "Double Kick"
+    "name": "Double Kick",
+    "effect": "O usuário ataca chutando o alvo duas vezes seguidas usando os dois pés."
   },
   "megaKick": {
     "name": "Mega Kick",
     "effect": "O alvo é atingido por um chute desferido com grande força muscular."
   },
   "jumpKick": {
-    "name": "Jump Kick"
+    "name": "Jump Kick",
+    "effect": "O usuário salta bem alto e então acerta com um chute. Se este movimento errar ou falhar, o usuário recebe dano igual à metade de seus PS máximos."
   },
   "rollingKick": {
-    "name": "Rolling Kick"
+    "name": "Rolling Kick",
+    "effect": "O usuário desfere um chute rápido e giratório. Este movimento tem 30% de chance de fazer o alvo hesitar."
   },
   "sandAttack": {
-    "name": "Sand Attack"
+    "name": "Sand Attack",
+    "effect": "Areia é arremessada no rosto do alvo, reduzindo a Precisão do alvo."
   },
   "headbutt": {
-    "name": "Headbutt"
+    "name": "Headbutt",
+    "effect": "O usuário estica a cabeça e ataca investindo diretamente contra o alvo. Este movimento tem 30% de chance de fazer o alvo hesitar."
   },
   "hornAttack": {
     "name": "Horn Attack",
     "effect": "O alvo é perfurado por um chifre pontudo e afiado para infligir dano."
   },
   "furyAttack": {
-    "name": "Fury Attack"
+    "name": "Fury Attack",
+    "effect": "O usuário ataca perfurando o alvo com um chifre, um bico ou algo do tipo. Este movimento atinge de duas a cinco vezes seguidas."
   },
   "hornDrill": {
-    "name": "Horn Drill"
+    "name": "Horn Drill",
+    "effect": "O usuário perfura o alvo com um chifre que gira como uma broca. O alvo desmaia instantaneamente se este ataque acertar, a menos que seja um Pokémon Chefe. A precisão deste movimento é fixada em 30%."
   },
   "tackle": {
     "name": "Tackle",
     "effect": "Um ataque físico cujo o usuário vai para cima do alvo e lhe atinge com todo o seu corpo."
   },
   "bodySlam": {
-    "name": "Body Slam"
+    "name": "Body Slam",
+    "effect": "O usuário ataca caindo sobre o alvo com todo o peso de seu corpo. Este movimento tem 30% de chance de paralisar o alvo. Se o alvo tiver usado Minimize, o poder deste movimento é duplicado e ele sempre acertará."
   },
   "wrap": {
-    "name": "Wrap"
+    "name": "Wrap",
+    "effect": "Um corpo longo, vinhas ou algo parecido são usados para envolver e apertar o alvo. Por 4 a 5 turnos, o alvo recebe dano igual a um oitavo de seus PS máximos ao final de cada turno."
   },
   "takeDown": {
-    "name": "Take Down"
+    "name": "Take Down",
+    "effect": "Uma investida imprudente de corpo inteiro para se chocar contra o alvo. O usuário recebe um quarto do dano causado por este movimento."
   },
   "thrash": {
-    "name": "Thrash"
+    "name": "Thrash",
+    "effect": "O usuário se descontrola e ataca por 2 a 3 turnos. O usuário então fica confuso."
   },
   "doubleEdge": {
-    "name": "Double-Edge"
+    "name": "Double-Edge",
+    "effect": "Uma investida imprudente que arrisca a vida, na qual o usuário se lança contra o alvo. O usuário recebe um terço do dano causado por este movimento."
   },
   "tailWhip": {
-    "name": "Tail Whip"
+    "name": "Tail Whip",
+    "effect": "O usuário balança a cauda de forma fofa, deixando os Pokémon adversários menos atentos. Isso reduz os atributos de Defesa deles."
   },
   "poisonSting": {
-    "name": "Poison Sting"
+    "name": "Poison Sting",
+    "effect": "O usuário perfura o alvo com um ferrão venenoso para causar dano. Este movimento tem 30% de chance de envenenar o alvo."
   },
   "twineedle": {
-    "name": "Twineedle"
+    "name": "Twineedle",
+    "effect": "O usuário causa dano ao alvo duas vezes seguidas, perfurando-o com dois espinhos. Cada acerto tem 20% de chance de envenenar o alvo."
   },
   "pinMissile": {
-    "name": "Pin Missile"
+    "name": "Pin Missile",
+    "effect": "O usuário ataca disparando espinhos afiados no alvo. Este movimento atinge de duas a cinco vezes seguidas."
   },
   "leer": {
-    "name": "Leer"
+    "name": "Leer",
+    "effect": "O usuário lança um olhar intimidador nos Pokémon adversários, reduzindo os atributos de Defesa deles."
   },
   "bite": {
-    "name": "Bite"
+    "name": "Bite",
+    "effect": "O alvo é mordido por presas cruelmente afiadas. Este movimento tem 30% de chance de fazer o alvo hesitar."
   },
   "growl": {
     "name": "Growl",
     "effect": "O usuário rosna de maneira agradável, baixando a guarda do Pokémon adversário. Isso diminui o Ataque do oponente."
   },
   "roar": {
-    "name": "Roar"
+    "name": "Roar",
+    "effect": "O usuário se move por último e solta um poderoso rugido. O alvo é assustado e um Pokémon diferente é arrastado para a batalha. Em batalhas selvagens, isso encerra a batalha contra um único Pokémon."
   },
   "sing": {
-    "name": "Sing"
+    "name": "Sing",
+    "effect": "Uma cantiga de ninar suave é cantada com uma bela voz que faz o alvo dormir."
   },
   "supersonic": {
     "name": "Supersonic",
@@ -160,19 +196,24 @@
     "effect": "O alvo é atingido com uma onda de choque destrutiva que sempre causa dano de 20 PS."
   },
   "disable": {
-    "name": "Disable"
+    "name": "Disable",
+    "effect": "Por 4 turnos, o alvo ficará impossibilitado de usar o último movimento que utilizou."
   },
   "acid": {
-    "name": "Acid"
+    "name": "Acid",
+    "effect": "Os Pokémon adversários são atacados com um jato de ácido corrosivo. Este movimento tem 10% de chance de reduzir os atributos de Defesa Especial deles."
   },
   "ember": {
-    "name": "Ember"
+    "name": "Ember",
+    "effect": "O alvo é atacado com pequenas chamas. Este movimento tem 10% de chance de causar queimadura no alvo."
   },
   "flamethrower": {
-    "name": "Flamethrower"
+    "name": "Flamethrower",
+    "effect": "O alvo é chamuscado por uma intensa rajada de fogo. Este movimento tem 10% de chance de causar queimadura no alvo."
   },
   "mist": {
-    "name": "Mist"
+    "name": "Mist",
+    "effect": "O usuário envolve a si mesmo e seus aliados em uma névoa branca que impede que qualquer um de seus atributos seja reduzido por 5 turnos."
   },
   "waterGun": {
     "name": "Water Gun",
@@ -183,42 +224,52 @@
     "effect": "O alvo é atingido por um enorme volume de água lançado sob uma forte pressão."
   },
   "surf": {
-    "name": "Surf"
+    "name": "Surf",
+    "effect": "O usuário ataca tudo ao seu redor inundando os arredores com uma onda gigante. O poder deste movimento é duplicado contra alvos submersos por Dive."
   },
   "iceBeam": {
-    "name": "Ice Beam"
+    "name": "Ice Beam",
+    "effect": "O alvo é atingido por um raio de energia gélida. Este movimento tem 10% de chance de congelar o alvo."
   },
   "blizzard": {
-    "name": "Blizzard"
+    "name": "Blizzard",
+    "effect": "Uma nevasca uivante é invocada para atingir os Pokémon adversários. Este movimento tem 10% de chance de congelar o alvo e nunca erra na neve ou no granizo."
   },
   "psybeam": {
-    "name": "Psybeam"
+    "name": "Psybeam",
+    "effect": "O alvo é atacado com um raio peculiar. Este movimento tem 10% de chance de confundir o alvo."
   },
   "bubbleBeam": {
-    "name": "Bubble Beam"
+    "name": "Bubble Beam",
+    "effect": "Um jato de bolhas é ejetado com força no alvo. Este movimento tem 10% de chance de reduzir o atributo de Velocidade do alvo."
   },
   "auroraBeam": {
-    "name": "Aurora Beam"
+    "name": "Aurora Beam",
+    "effect": "O alvo é atingido por um raio da cor do arco-íris. Este movimento tem 10% de chance de reduzir o atributo de Ataque do alvo."
   },
   "hyperBeam": {
     "name": "Hyper Beam",
     "effect": "O alvo é atingido por um raio poderoso. O usuário não poderá se mover no próximo turno."
   },
   "peck": {
-    "name": "Peck"
+    "name": "Peck",
+    "effect": "O alvo é perfurado por um bico ou chifre pontiagudo para causar dano."
   },
   "drillPeck": {
     "name": "Drill Peck",
     "effect": "Um ataque giratório com um bico afiado que age como uma broca."
   },
   "submission": {
-    "name": "Submission"
+    "name": "Submission",
+    "effect": "O usuário agarra o alvo e mergulha imprudentemente em direção ao chão. O usuário recebe um quarto do dano causado por este movimento."
   },
   "lowKick": {
-    "name": "Low Kick"
+    "name": "Low Kick",
+    "effect": "Um poderoso chute baixo que derruba o alvo. Quanto mais pesado o alvo, maior o poder do movimento (variando entre 20 e 120)."
   },
   "counter": {
-    "name": "Counter"
+    "name": "Counter",
+    "effect": "Um ataque de retaliação que revida qualquer movimento físico, causando o dobro do dano recebido."
   },
   "seismicToss": {
     "name": "Seismic Toss",
@@ -229,22 +280,28 @@
     "effect": "O alvo é atingido por um soco dado com o máximo de força."
   },
   "absorb": {
-    "name": "Absorb"
+    "name": "Absorb",
+    "effect": "Um ataque que drena nutrientes. Os PS do usuário são restaurados em metade do dano causado por este movimento."
   },
   "megaDrain": {
-    "name": "Mega Drain"
+    "name": "Mega Drain",
+    "effect": "Um ataque que drena nutrientes. Os PS do usuário são restaurados em metade do dano causado por este movimento."
   },
   "leechSeed": {
-    "name": "Leech Seed"
+    "name": "Leech Seed",
+    "effect": "Uma semente é plantada no alvo. Ao final de cada turno, um oitavo dos PS máximos do alvo é absorvido pelo usuário ou por qualquer Pokémon que assuma seu lugar na batalha."
   },
   "growth": {
-    "name": "Growth"
+    "name": "Growth",
+    "effect": "O corpo do usuário cresce de uma só vez, aumentando seus atributos de Ataque e Ataque Especial. Sob sol forte, esses atributos são aumentados bruscamente."
   },
   "razorLeaf": {
-    "name": "Razor Leaf"
+    "name": "Razor Leaf",
+    "effect": "Folhas de bordas afiadas são lançadas para cortar os Pokémon adversários. A taxa de golpe crítico deste movimento é aumentada em 1 estágio."
   },
   "solarBeam": {
-    "name": "Solar Beam"
+    "name": "Solar Beam",
+    "effect": "O usuário reúne luz no primeiro turno e dispara um raio concentrado no turno seguinte. Sob sol forte, o usuário pode atacar imediatamente. O poder deste movimento é reduzido pela metade em qualquer outra condição climática."
   },
   "poisonPowder": {
     "name": "Poison Powder",
@@ -255,93 +312,116 @@
     "effect": "O usuário espalha uma nuvem de esporos entorpecentes que paralisam o alvo."
   },
   "sleepPowder": {
-    "name": "Sleep Powder"
+    "name": "Sleep Powder",
+    "effect": "O usuário espalha uma nuvem de poeira soporífera que faz o alvo dormir."
   },
   "petalDance": {
-    "name": "Petal Dance"
+    "name": "Petal Dance",
+    "effect": "O usuário ataca o alvo espalhando pétalas por 2 a 3 turnos. O usuário então fica confuso."
   },
   "stringShot": {
-    "name": "String Shot"
+    "name": "String Shot",
+    "effect": "O usuário sopra seda de sua boca que prende os Pokémon adversários e reduz duramente o atributo de Velocidade deles."
   },
   "dragonRage": {
     "name": "Dragon Rage",
     "effect": "Este ataque atinge o alvo com uma onda de choque de pura fúria. Este ataque sempre causa 40 PS de dano."
   },
   "fireSpin": {
-    "name": "Fire Spin"
+    "name": "Fire Spin",
+    "effect": "O usuário prende o alvo dentro de um feroz vórtice de fogo. Por 4 a 5 turnos, o alvo recebe dano igual a um oitavo de seus PS máximos ao final de cada turno."
   },
   "thunderShock": {
-    "name": "Thunder Shock"
+    "name": "Thunder Shock",
+    "effect": "O usuário ataca o alvo com uma descarga de eletricidade. Este movimento tem 10% de chance de paralisar o alvo."
   },
   "thunderbolt": {
-    "name": "Thunderbolt"
+    "name": "Thunderbolt",
+    "effect": "O usuário ataca o alvo com uma forte rajada elétrica. Este movimento tem 10% de chance de paralisar o alvo."
   },
   "thunderWave": {
     "name": "Thunder Wave",
     "effect": "O usuário lança um choque elétrico fraco que paralisa o alvo."
   },
   "thunder": {
-    "name": "Thunder"
+    "name": "Thunder",
+    "effect": "Um raio cruel é lançado sobre o alvo para causar dano. Este movimento tem 30% de chance de paralisar o alvo e nunca erra na chuva. Este movimento também pode atingir um alvo que esteja no ar por Fly, Bounce ou Sky Drop."
   },
   "rockThrow": {
-    "name": "Rock Throw"
+    "name": "Rock Throw",
+    "effect": "O usuário pega e arremessa uma pequena rocha no alvo para causar dano."
   },
   "earthquake": {
-    "name": "Earthquake"
+    "name": "Earthquake",
+    "effect": "O usuário desencadeia um terremoto que atinge todos os Pokémon ao seu redor. O poder deste movimento é duplicado contra alvos subterrâneos por Dig e reduzido pela metade enquanto o Terreno de Grama estiver ativo."
   },
   "fissure": {
-    "name": "Fissure"
+    "name": "Fissure",
+    "effect": "O usuário abre uma fenda no chão e derruba o alvo nela. O alvo desmaia instantaneamente se este ataque acertar, a menos que seja um Pokémon Chefe. A precisão deste movimento é fixada em 30%."
   },
   "dig": {
-    "name": "Dig"
+    "name": "Dig",
+    "effect": "O usuário cava para dentro do chão no primeiro turno e ataca no turno seguinte."
   },
   "toxic": {
-    "name": "Toxic"
+    "name": "Toxic",
+    "effect": "Um movimento que deixa o alvo gravemente envenenado. O alvo recebe dano de veneno crescente ao final de cada turno, começando em um dezesseis avos dos PS máximos do Pokémon, depois dois dezesseis avos e assim por diante. Se o usuário for do tipo Venenoso, este movimento nunca errará."
   },
   "confusion": {
-    "name": "Confusion"
+    "name": "Confusion",
+    "effect": "O alvo é atingido por uma fraca força telecinética para causar dano. Este movimento tem 10% de chance de confundir o alvo."
   },
   "psychic": {
-    "name": "Psychic"
+    "name": "Psychic",
+    "effect": "O alvo é atingido por uma forte força telecinética para causar dano. Este movimento tem 10% de chance de reduzir o atributo de Defesa Especial do alvo."
   },
   "hypnosis": {
-    "name": "Hypnosis"
+    "name": "Hypnosis",
+    "effect": "O usuário emprega sugestão hipnótica para fazer o alvo adormecer."
   },
   "meditate": {
-    "name": "Meditate"
+    "name": "Meditate",
+    "effect": "O usuário medita para despertar o poder oculto dentro de seu corpo, aumentando o atributo de Ataque do usuário."
   },
   "agility": {
-    "name": "Agility"
+    "name": "Agility",
+    "effect": "O usuário relaxa e alivia seu corpo para se mover mais rápido. Isso aumenta bruscamente seu atributo de Velocidade."
   },
   "quickAttack": {
-    "name": "Quick Attack"
+    "name": "Quick Attack",
+    "effect": "O usuário se lança sobre o alvo para causar dano, movendo-se a uma velocidade cegante. Este movimento sempre ocorre primeiro."
   },
   "rage": {
     "name": "Rage",
     "effect": "Enquanto este movimento estiver em uso, o poder da ira aumenta o Ataque toda vez que o usuário for atingido em batalha."
   },
   "teleport": {
-    "name": "Teleport"
+    "name": "Teleport",
+    "effect": "O usuário se move por último e troca de lugar com um Pokémon da equipe que esteja aguardando, se houver. Se um Pokémon selvagem usar este movimento, ele foge."
   },
   "nightShade": {
     "name": "Night Shade",
     "effect": "O usuário faz com que o alvo veja uma miragem assustadora. Isso causa dano igual ao nível do usuário."
   },
   "mimic": {
-    "name": "Mimic"
+    "name": "Mimic",
+    "effect": "O usuário copia o último movimento usado pelo alvo. O movimento copiado pode ser usado até que o usuário de Mimic saia da batalha."
   },
   "screech": {
     "name": "Screech",
     "effect": "Um grito estridente que reduz duramente o atributo de Defesa do alvo."
   },
   "doubleTeam": {
-    "name": "Double Team"
+    "name": "Double Team",
+    "effect": "Movendo-se rapidamente, o usuário cria cópias ilusórias de si mesmo para aumentar sua evasão."
   },
   "recover": {
-    "name": "Recover"
+    "name": "Recover",
+    "effect": "O usuário regenera suas células, restaurando metade de seus PS máximos."
   },
   "harden": {
-    "name": "Harden"
+    "name": "Harden",
+    "effect": "O usuário enrijece todos os músculos de seu corpo para aumentar seu atributo de Defesa."
   },
   "minimize": {
     "name": "Minimize",
@@ -352,40 +432,48 @@
     "effect": "O usuário lança uma nuvem obscura de fumaça ou tinta. Isso diminui a Precisão do alvo."
   },
   "confuseRay": {
-    "name": "Confuse Ray"
+    "name": "Confuse Ray",
+    "effect": "O usuário emite um raio sinistro no alvo, deixando-o confuso."
   },
   "withdraw": {
-    "name": "Withdraw"
+    "name": "Withdraw",
+    "effect": "O usuário recolhe seu corpo para dentro de sua concha rígida, aumentando seu atributo de Defesa."
   },
   "defenseCurl": {
-    "name": "Defense Curl"
+    "name": "Defense Curl",
+    "effect": "O usuário se enrola para ocultar pontos fracos, o que aumenta seu atributo de Defesa. Isso também duplica o poder de Rollout e Ice Ball."
   },
   "barrier": {
     "name": "Barrier",
     "effect": "O usuário ergue uma barreira robusta que aumenta bruscamente a sua Defesa."
   },
   "lightScreen": {
-    "name": "Light Screen"
+    "name": "Light Screen",
+    "effect": "Uma maravilhosa parede de luz é erguida para reduzir pela metade o dano recebido de movimentos especiais por 5 turnos. Em Batalhas Duplas, esse dano é reduzido em um terço."
   },
   "haze": {
     "name": "Haze",
     "effect": "O usuário cria uma névoa que elimina todas as alterações de atributos de todos os Pokémon em batalha."
   },
   "reflect": {
-    "name": "Reflect"
+    "name": "Reflect",
+    "effect": "Uma maravilhosa parede de luz é erguida para reduzir pela metade o dano recebido de movimentos físicos por 5 turnos. Em Batalhas Duplas, esse dano é reduzido em um terço."
   },
   "focusEnergy": {
-    "name": "Focus Energy"
+    "name": "Focus Energy",
+    "effect": "O usuário respira fundo e se concentra, ganhando um aumento de 2 estágios na taxa de golpe crítico de seus ataques futuros."
   },
   "bide": {
-    "name": "Bide"
+    "name": "Bide",
+    "effect": "O usuário suporta ataques por 2 turnos e então revida causando o dobro do dano recebido."
   },
   "metronome": {
     "name": "Metronome",
     "effect": "O usuário balança um dedo e estimula seu cérebro para usar aleatoriamente quase qualquer movimento."
   },
   "mirrorMove": {
-    "name": "Mirror Move"
+    "name": "Mirror Move",
+    "effect": "O usuário revida ao alvo imitando o último movimento do alvo. Este movimento falha se nenhum outro movimento tiver sido usado ainda ou se o último movimento usado não puder ser copiado."
   },
   "selfDestruct": {
     "name": "Self-Destruct",
@@ -396,25 +484,32 @@
     "effect": "Um ovo grande é arremessado contra o alvo com força máxima para causar dano."
   },
   "lick": {
-    "name": "Lick"
+    "name": "Lick",
+    "effect": "O usuário lambe o alvo com uma língua comprida para causar dano. Este movimento tem 30% de chance de paralisar o alvo."
   },
   "smog": {
-    "name": "Smog"
+    "name": "Smog",
+    "effect": "O alvo é atacado com uma descarga de gases imundos. Este movimento tem 30% de chance de envenenar o alvo."
   },
   "sludge": {
-    "name": "Sludge"
+    "name": "Sludge",
+    "effect": "O usuário arremessa lodo insalubre no alvo para causar dano. Este movimento tem 30% de chance de envenenar o alvo."
   },
   "boneClub": {
-    "name": "Bone Club"
+    "name": "Bone Club",
+    "effect": "O usuário golpeia o alvo com um osso. Este movimento tem 10% de chance de fazer o alvo hesitar."
   },
   "fireBlast": {
-    "name": "Fire Blast"
+    "name": "Fire Blast",
+    "effect": "O alvo é atacado com uma intensa explosão de fogo devastador. Este movimento tem 10% de chance de causar queimadura no alvo."
   },
   "waterfall": {
-    "name": "Waterfall"
+    "name": "Waterfall",
+    "effect": "O usuário ataca investindo contra o alvo com um ímpeto incrível. Este movimento tem 20% de chance de fazer o alvo hesitar."
   },
   "clamp": {
-    "name": "Clamp"
+    "name": "Clamp",
+    "effect": "O alvo é preso e apertado pela concha grossa e resistente do usuário. Por 4 a 5 turnos, o alvo recebe dano igual a um oitavo de seus PS máximos ao final de cada turno."
   },
   "swift": {
     "name": "Swift",
@@ -425,53 +520,68 @@
     "effect": "O usuário retrai sua cabeça para aumentar a Defesa no primeiro turno e depois se choca com o alvo no próximo turno."
   },
   "spikeCannon": {
-    "name": "Spike Cannon"
+    "name": "Spike Cannon",
+    "effect": "Espinhos afiados são disparados no alvo em rápida sucessão. Eles atingem de duas a cinco vezes seguidas."
   },
   "constrict": {
-    "name": "Constrict"
+    "name": "Constrict",
+    "effect": "O alvo é atacado com tentáculos longos e rastejantes, vinhas ou algo do tipo. Este movimento tem 10% de chance de reduzir o atributo de Velocidade do alvo."
   },
   "amnesia": {
-    "name": "Amnesia"
+    "name": "Amnesia",
+    "effect": "O usuário esvazia temporariamente sua mente para esquecer suas preocupações. Isso aumenta bruscamente o atributo de Defesa Especial do usuário."
   },
   "kinesis": {
     "name": "Kinesis",
     "effect": "O usuário distrai o alvo entortando uma colher. Isso diminui a Precisão do alvo."
   },
   "softBoiled": {
-    "name": "Soft-Boiled"
+    "name": "Soft-Boiled",
+    "effect": "O usuário produz para si um grande ovo, restaurando metade de seus PS máximos."
   },
   "highJumpKick": {
-    "name": "High Jump Kick"
+    "name": "High Jump Kick",
+    "effect": "O alvo é atacado com uma joelhada dada a partir de um salto. Se este movimento errar ou falhar, o usuário recebe dano igual à metade de seus PS máximos."
   },
   "glare": {
-    "name": "Glare"
+    "name": "Glare",
+    "effect": "O usuário intimida o alvo com um olhar aterrorizante que o deixa paralisado."
   },
   "dreamEater": {
-    "name": "Dream Eater"
+    "name": "Dream Eater",
+    "effect": "O usuário devora os sonhos de um alvo adormecido. Os PS do usuário são restaurados em metade do dano causado por este movimento."
   },
   "poisonGas": {
-    "name": "Poison Gas"
+    "name": "Poison Gas",
+    "effect": "Uma nuvem de gás venenoso é lançada no rosto dos Pokémon adversários, envenenando aqueles que atingir."
   },
   "barrage": {
-    "name": "Barrage"
+    "name": "Barrage",
+    "effect": "Objetos redondos são arremessados no alvo. Este movimento atinge de duas a cinco vezes seguidas."
   },
   "leechLife": {
-    "name": "Leech Life"
+    "name": "Leech Life",
+    "effect": "O usuário drena o sangue do alvo. Os PS do usuário são restaurados em metade do dano causado por este movimento."
   },
   "lovelyKiss": {
-    "name": "Lovely Kiss"
+    "name": "Lovely Kiss",
+    "effect": "Com uma expressão assustadora, o usuário tenta beijar o alvo. Se conseguir, o alvo cai no sono."
   },
   "skyAttack": {
-    "name": "Sky Attack"
+    "name": "Sky Attack",
+    "effect": "O usuário ataca com um mergulho potencializado no turno seguinte ao uso deste movimento. A taxa de golpe crítico deste movimento é aumentada em 1 estágio e ele tem 30% de chance de fazer o alvo hesitar."
   },
   "transform": {
-    "name": "Transform"
+    "name": "Transform",
+    "effect": "O usuário se transforma em uma cópia do alvo, até mesmo com o mesmo conjunto de movimentos. Ele também copia todos os atributos do alvo, exceto seus PS. Os movimentos copiados têm 5 PP cada."
   },
   "bubble": {
-    "name": "Bubble"
+    "name": "Bubble",
+    "effect": "Um jato de incontáveis bolhas é lançado nos Pokémon adversários. Este movimento tem 10% de chance de reduzir os atributos de Velocidade deles."
   },
   "dizzyPunch": {
-    "name": "Dizzy Punch"
+    "name": "Dizzy Punch",
+    "effect": "O alvo é atingido por socos lançados ritmicamente. Este movimento tem 20% de chance de confundir o alvo."
   },
   "spore": {
     "name": "Spore",
@@ -482,37 +592,44 @@
     "effect": "O usuário pisca uma luz brilhante que reduz a Precisão do alvo."
   },
   "psywave": {
-    "name": "Psywave"
+    "name": "Psywave",
+    "effect": "O alvo é atacado com uma estranha onda psíquica. Este ataque varia em dano, indo de 50% a 150% do nível do usuário."
   },
   "splash": {
     "name": "Splash",
     "effect": "O usuário apenas debate-se no chão e espirra água ao seu redor sem efeito algum…"
   },
   "acidArmor": {
-    "name": "Acid Armor"
+    "name": "Acid Armor",
+    "effect": "O usuário altera sua estrutura celular para se liquefazer, aumentando bruscamente seu atributo de Defesa."
   },
   "crabhammer": {
-    "name": "Crabhammer"
+    "name": "Crabhammer",
+    "effect": "O alvo é martelado com uma grande pinça. A taxa de golpe crítico deste movimento é aumentada em 1 estágio."
   },
   "explosion": {
     "name": "Explosion",
     "effect": "O usuário ataca tudo o que estiver à sua volta causando uma tremenda explosão. O usuário desmaia ao usar esse movimento."
   },
   "furySwipes": {
-    "name": "Fury Swipes"
+    "name": "Fury Swipes",
+    "effect": "O usuário ataca dilacerando o alvo com garras, foices ou algo do tipo. Este movimento atinge de duas a cinco vezes seguidas."
   },
   "bonemerang": {
-    "name": "Bonemerang"
+    "name": "Bonemerang",
+    "effect": "O usuário arremessa o osso que segura. O osso volta em curva, causando dano ao alvo duas vezes — na ida e na volta."
   },
   "rest": {
     "name": "Rest",
     "effect": "O usuário adormece por 2 turnos. Isso restaura totalmente os PS do usuário e cura quaisquer condições de status. Este movimento falha se os PS do usuário estiverem cheios."
   },
   "rockSlide": {
-    "name": "Rock Slide"
+    "name": "Rock Slide",
+    "effect": "Grandes pedregulhos são arremessados nos Pokémon adversários para causar dano. Este movimento tem 30% de chance de fazer os alvos hesitarem."
   },
   "hyperFang": {
-    "name": "Hyper Fang"
+    "name": "Hyper Fang",
+    "effect": "O usuário morde com força o alvo com suas afiadas presas dianteiras. Este movimento tem 10% de chance de fazer o alvo hesitar."
   },
   "sharpen": {
     "name": "Sharpen",
@@ -523,73 +640,92 @@
     "effect": "O usuário muda seu tipo para o mesmo tipo do movimento no topo da lista dos movimentos que conhece no momento."
   },
   "triAttack": {
-    "name": "Tri Attack"
+    "name": "Tri Attack",
+    "effect": "O usuário ataca com três feixes simultâneos. Este movimento tem 20% de chance de deixar o alvo queimado, congelado ou paralisado."
   },
   "superFang": {
-    "name": "Super Fang"
+    "name": "Super Fang",
+    "effect": "O usuário morde com força o alvo com suas afiadas presas dianteiras. Isso causa ao alvo dano igual à metade de seus PS restantes."
   },
   "slash": {
-    "name": "Slash"
+    "name": "Slash",
+    "effect": "O alvo é atacado com um corte de garras, foices ou algo do tipo. A taxa de golpe crítico deste movimento é aumentada em 1 estágio."
   },
   "substitute": {
-    "name": "Substitute"
+    "name": "Substitute",
+    "effect": "O usuário cria um substituto de si mesmo perdendo um quarto de seus PS máximos. O substituto serve como isca para o usuário e desaparecerá quando receber dano igual à quantidade de PS perdida pelo usuário para criá-lo."
   },
   "struggle": {
-    "name": "Struggle"
+    "name": "Struggle",
+    "effect": "Este ataque é usado em desespero apenas se o usuário não tiver mais PP. O usuário perde um quarto de seus PS máximos."
   },
   "sketch": {
-    "name": "Sketch"
+    "name": "Sketch",
+    "effect": "Este movimento permite que o usuário aprenda permanentemente o último movimento usado pelo alvo. Uma vez usado, Sketch desaparece."
   },
   "tripleKick": {
-    "name": "Triple Kick"
+    "name": "Triple Kick",
+    "effect": "Um ataque consecutivo de três chutes que aumenta o poder em 10 a cada acerto sucessivo. Quando um chute erra, o movimento termina."
   },
   "thief": {
     "name": "Thief",
     "effect": "O usuário ataca e tenta roubar o alvo simultaneamente. Este movimento tem 30% de chance de roubar um dos itens que o alvo está segurando."
   },
   "spiderWeb": {
-    "name": "Spider Web"
+    "name": "Spider Web",
+    "effect": "O usuário enreda o alvo com uma seda fina e pegajosa para que ele não possa fugir ou ser trocado da batalha."
   },
   "mindReader": {
     "name": "Mind Reader",
     "effect": "O usuário pressente os movimentos do alvo com sua mente para ter certeza que o seu próximo ataque não o erre."
   },
   "nightmare": {
-    "name": "Nightmare"
+    "name": "Nightmare",
+    "effect": "Um alvo adormecido tem um pesadelo que causa dano igual a um quarto de seus PS máximos ao final de cada turno. Isso falha se o alvo não estiver dormindo."
   },
   "flameWheel": {
-    "name": "Flame Wheel"
+    "name": "Flame Wheel",
+    "effect": "O usuário ataca envolvendo-se em fogo e investindo contra o alvo. Este movimento tem 10% de chance de causar queimadura no alvo e descongela o usuário caso ele esteja congelado."
   },
   "snore": {
-    "name": "Snore"
+    "name": "Snore",
+    "effect": "Se o usuário estiver dormindo, ele ataca com um ruído estridente. Este movimento tem 30% de chance de fazer o alvo hesitar."
   },
   "curse": {
-    "name": "Curse"
+    "name": "Curse",
+    "effect": "O usuário aumenta seus atributos de Ataque e Defesa em troca de reduzir seu atributo de Velocidade. Se o usuário for do tipo Fantasma, ele perde metade de seus PS máximos para infligir uma maldição no alvo. Um Pokémon afetado pela maldição perde um quarto de seus PS máximos ao final de cada turno."
   },
   "flail": {
-    "name": "Flail"
+    "name": "Flail",
+    "effect": "O usuário se debate sem rumo para atacar. Quanto menos PS o usuário tiver, maior o poder do movimento (variando entre 20 e 200)."
   },
   "conversion2": {
-    "name": "Conversion 2"
+    "name": "Conversion 2",
+    "effect": "O usuário muda seu tipo para se tornar resistente ao tipo do último movimento usado pelo alvo."
   },
   "aeroblast": {
-    "name": "Aeroblast"
+    "name": "Aeroblast",
+    "effect": "Um vórtice de ar é disparado no alvo para causar dano. A taxa de golpe crítico deste movimento é aumentada em 1 estágio."
   },
   "cottonSpore": {
-    "name": "Cotton Spore"
+    "name": "Cotton Spore",
+    "effect": "O usuário libera esporos semelhantes a algodão que grudam nos Pokémon adversários. Isso reduz duramente os atributos de Velocidade deles."
   },
   "reversal": {
-    "name": "Reversal"
+    "name": "Reversal",
+    "effect": "Um ataque total que se torna mais poderoso quanto menos PS o usuário tiver (variando entre 20 e 200)."
   },
   "spite": {
     "name": "Spite",
     "effect": "O usuário libera todo o seu rancor no último movimento usado pelo oponente, cortando 4 PP do mesmo."
   },
   "powderSnow": {
-    "name": "Powder Snow"
+    "name": "Powder Snow",
+    "effect": "O usuário ataca os Pokémon adversários com uma rajada gélida de neve em pó. Este movimento tem 10% de chance de congelar os alvos."
   },
   "protect": {
-    "name": "Protect"
+    "name": "Protect",
+    "effect": "Este movimento permite que o usuário se proteja de todos os ataques. A cada uso consecutivo, a chance de sucesso deste movimento se torna um terço do que era antes."
   },
   "machPunch": {
     "name": "Mach Punch",
@@ -608,186 +744,232 @@
     "effect": "O usuário beija o alvo com uma fofura doce e angelical, causando confusão."
   },
   "bellyDrum": {
-    "name": "Belly Drum"
+    "name": "Belly Drum",
+    "effect": "O usuário perde metade de seus PS máximos para maximizar seu atributo de Ataque. Este movimento falha se o usuário não tiver PS restantes suficientes."
   },
   "sludgeBomb": {
-    "name": "Sludge Bomb"
+    "name": "Sludge Bomb",
+    "effect": "O usuário arremessa lodo insalubre no alvo para causar dano. Este movimento tem 30% de chance de envenenar o alvo."
   },
   "mudSlap": {
     "name": "Mud-Slap",
     "effect": "O usuário arremessa lama no rosto do adversário para causar dano e prejudicar sua precisão."
   },
   "octazooka": {
-    "name": "Octazooka"
+    "name": "Octazooka",
+    "effect": "O usuário ataca lançando tinta no rosto do alvo. Este movimento tem 50% de chance de reduzir a Precisão do alvo."
   },
   "spikes": {
-    "name": "Spikes"
+    "name": "Spikes",
+    "effect": "O usuário arma uma armadilha de espinhos aos pés da equipe adversária, causando dano aos Pokémon adversários que entrarem na batalha igual a um oitavo de seus PS máximos. Esse dano aumenta com múltiplas camadas de Spikes, até um máximo de 3. Tipos Voadores ou Pokémon com Levitate não são afetados."
   },
   "zapCannon": {
-    "name": "Zap Cannon"
+    "name": "Zap Cannon",
+    "effect": "O usuário ataca disparando uma rajada elétrica como um canhão. Isso também deixa o alvo paralisado."
   },
   "foresight": {
     "name": "Foresight",
     "effect": "Permite que um alvo do tipo Fantasma seja atingido por ataques do tipo Normal e Lutador. Isso também permite que um alvo evasivo seja acertado."
   },
   "destinyBond": {
-    "name": "Destiny Bond"
+    "name": "Destiny Bond",
+    "effect": "Se o usuário for nocauteado após usar este movimento, o Pokémon que o nocauteou também desmaiará. Este movimento falha se usado em sucessão. Pokémon Chefe são imunes a este movimento."
   },
   "perishSong": {
-    "name": "Perish Song"
+    "name": "Perish Song",
+    "effect": "Qualquer Pokémon que ouça esta canção desmaia em 3 turnos, a menos que seja trocado da batalha. Pokémon Chefe são imunes a este movimento."
   },
   "icyWind": {
     "name": "Icy Wind",
     "effect": "O usuário ataca com uma rajada de ar frio. Isso também reduz os atributos de Velocidade do Pokémon adversário."
   },
   "detect": {
-    "name": "Detect"
+    "name": "Detect",
+    "effect": "Este movimento permite que o usuário se proteja de todos os ataques. A cada uso consecutivo, a chance de sucesso deste movimento se torna um terço do que era antes."
   },
   "boneRush": {
-    "name": "Bone Rush"
+    "name": "Bone Rush",
+    "effect": "O usuário ataca golpeando o alvo com um osso rígido. Este movimento atinge de duas a cinco vezes seguidas."
   },
   "lockOn": {
-    "name": "Lock-On"
+    "name": "Lock-On",
+    "effect": "O usuário mira com precisão no alvo. Isso garante que o próximo movimento do usuário não erre aquele alvo."
   },
   "outrage": {
-    "name": "Outrage"
+    "name": "Outrage",
+    "effect": "O usuário se descontrola e ataca por 2 a 3 turnos. O usuário então fica confuso."
   },
   "sandstorm": {
-    "name": "Sandstorm"
+    "name": "Sandstorm",
+    "effect": "O usuário invoca uma tempestade de areia por 5 turnos; Pokémon que não sejam dos tipos Pedra, Terrestre ou Aço recebem dano igual a um dezesseis avos de seus PS máximos ao final de cada turno. A tempestade de areia também aumenta em 50% os atributos de Defesa Especial dos tipos Pedra."
   },
   "gigaDrain": {
-    "name": "Giga Drain"
+    "name": "Giga Drain",
+    "effect": "Um ataque que drena nutrientes. Os PS do usuário são restaurados em metade do dano causado por este movimento."
   },
   "endure": {
-    "name": "Endure"
+    "name": "Endure",
+    "effect": "O usuário suporta qualquer ataque com pelo menos 1 PS. A cada uso consecutivo, a chance de sucesso deste movimento se torna um terço do que era antes."
   },
   "charm": {
     "name": "Charm",
     "effect": "O usuário contempla o alvo com um olhar charmoso, fazendo-o ficar menos atento. Isso prejudica duramente o Ataque do oponente."
   },
   "rollout": {
-    "name": "Rollout"
+    "name": "Rollout",
+    "effect": "O usuário rola continuamente contra o alvo ao longo de 5 turnos. Este ataque duplica seu poder a cada acerto e se reinicia após 5 turnos ou se o movimento for interrompido."
   },
   "falseSwipe": {
     "name": "False Swipe",
     "effect": "Um ataque moderado que previne que o alvo desmaie. O alvo é deixado com pelo menos 1 de PS."
   },
   "swagger": {
-    "name": "Swagger"
+    "name": "Swagger",
+    "effect": "O usuário enfurece e confunde o alvo. No entanto, isso também aumenta bruscamente o atributo de Ataque do alvo."
   },
   "milkDrink": {
-    "name": "Milk Drink"
+    "name": "Milk Drink",
+    "effect": "O usuário bebe leite altamente nutritivo, restaurando metade de seus PS máximos."
   },
   "spark": {
-    "name": "Spark"
+    "name": "Spark",
+    "effect": "O usuário ataca o alvo com uma investida eletricamente carregada. Este movimento tem 30% de chance de paralisar o alvo."
   },
   "furyCutter": {
-    "name": "Fury Cutter"
+    "name": "Fury Cutter",
+    "effect": "O usuário ataca cortando o alvo com foices, garras ou algo do tipo. O poder deste movimento é duplicado se acertar em sucessão, até um máximo de 160 de poder, e se reinicia se o movimento for interrompido ou outro movimento for usado."
   },
   "steelWing": {
-    "name": "Steel Wing"
+    "name": "Steel Wing",
+    "effect": "O alvo é atingido por asas de aço. Este movimento tem 10% de chance de aumentar o atributo de Defesa do usuário."
   },
   "meanLook": {
-    "name": "Mean Look"
+    "name": "Mean Look",
+    "effect": "O usuário prende o alvo com um olhar sombrio e cativante. O alvo fica impossibilitado de fugir ou ser trocado da batalha."
   },
   "attract": {
-    "name": "Attract"
+    "name": "Attract",
+    "effect": "Se o alvo for do gênero oposto ao do usuário, ele fica apaixonado pelo usuário e terá 50% de chance de ficar impossibilitado de usar seus movimentos."
   },
   "sleepTalk": {
-    "name": "Sleep Talk"
+    "name": "Sleep Talk",
+    "effect": "O usuário usa aleatoriamente um dos movimentos que conhece. Este movimento só pode ser usado enquanto o usuário estiver dormindo."
   },
   "healBell": {
     "name": "Heal Bell",
     "effect": "O usuário emite um som suave de sino para curar as condições de status de todos os Pokémon do seu grupo e aliados."
   },
   "return": {
-    "name": "Return"
+    "name": "Return",
+    "effect": "Este ataque de poder total se torna mais poderoso quanto mais o usuário gostar de seu Treinador (variando entre 1 e 102)."
   },
   "present": {
-    "name": "Present"
+    "name": "Present",
+    "effect": "O usuário ataca dando ao alvo um presente com uma armadilha escondida, causando aleatoriamente dano com 40, 80 ou 120 de poder. Às vezes, porém, o presente restaura um quarto dos PS máximos do alvo."
   },
   "frustration": {
-    "name": "Frustration"
+    "name": "Frustration",
+    "effect": "Este ataque de poder total se torna mais poderoso quanto menos o usuário gostar de seu Treinador (variando entre 1 e 102)."
   },
   "safeguard": {
     "name": "Safeguard",
     "effect": "O usuário cria um campo protetor que impede a aplicação de condições de status por 5 turnos."
   },
   "painSplit": {
-    "name": "Pain Split"
+    "name": "Pain Split",
+    "effect": "O usuário soma seus PS restantes aos PS restantes do alvo e depois divide o total pela metade para que compartilhem. Pokémon Chefe são imunes a este movimento."
   },
   "sacredFire": {
-    "name": "Sacred Fire"
+    "name": "Sacred Fire",
+    "effect": "O alvo é incinerado por um fogo místico de grande intensidade. Este movimento tem 50% de chance de causar queimadura no alvo e descongela o usuário caso ele esteja congelado."
   },
   "magnitude": {
-    "name": "Magnitude"
+    "name": "Magnitude",
+    "effect": "O usuário ataca tudo ao seu redor com um tremor que abala o solo. Seu poder varia de acordo com a magnitude do tremor, podendo ser 10, 30, 50, 70, 90, 110 ou 150 de poder. O poder deste movimento é duplicado contra alvos subterrâneos por Dig e reduzido pela metade enquanto o Terreno de Grama estiver ativo."
   },
   "dynamicPunch": {
-    "name": "Dynamic Punch"
+    "name": "Dynamic Punch",
+    "effect": "O usuário ataca socando o alvo com poder totalmente concentrado. Isso também confunde o alvo."
   },
   "megahorn": {
     "name": "Megahorn",
     "effect": "Usando seu impressionante chifre resistente, o usuário golpeia o alvo sem trégua."
   },
   "dragonBreath": {
-    "name": "Dragon Breath"
+    "name": "Dragon Breath",
+    "effect": "O usuário exala uma poderosa rajada que causa dano. Este movimento tem 30% de chance de paralisar o alvo."
   },
   "batonPass": {
-    "name": "Baton Pass"
+    "name": "Baton Pass",
+    "effect": "O usuário sai da batalha para ser substituído por outro Pokémon da equipe. Se o usuário tiver quaisquer mudanças de atributos, um substituto ou outros efeitos do tipo, eles serão passados para o Pokémon que entrar."
   },
   "encore": {
-    "name": "Encore"
+    "name": "Encore",
+    "effect": "O usuário obriga o alvo a continuar usando o movimento aclamado por 3 turnos."
   },
   "pursuit": {
     "name": "Pursuit",
     "effect": "Um ataque que causa o dobro do dano caso seja usado em um alvo que esteja sendo trocado para fora da batalha."
   },
   "rapidSpin": {
-    "name": "Rapid Spin"
+    "name": "Rapid Spin",
+    "effect": "O usuário realiza um ataque giratório que pode eliminar os efeitos de movimentos que prendem e de Leech Seed, bem como quaisquer armadilhas em seu lado do campo. Isso também aumenta o atributo de Velocidade do usuário."
   },
   "sweetScent": {
-    "name": "Sweet Scent"
+    "name": "Sweet Scent",
+    "effect": "O usuário libera um aroma que reduz duramente a evasão dos Pokémon adversários."
   },
   "ironTail": {
-    "name": "Iron Tail"
+    "name": "Iron Tail",
+    "effect": "O alvo é golpeado por uma cauda dura como aço. Este movimento tem 30% de chance de reduzir o atributo de Defesa do alvo."
   },
   "metalClaw": {
-    "name": "Metal Claw"
+    "name": "Metal Claw",
+    "effect": "O alvo é dilacerado por garras de aço. Este movimento tem 10% de chance de aumentar o atributo de Ataque do usuário."
   },
   "vitalThrow": {
     "name": "Vital Throw",
     "effect": "O usuário sempre ataca por último. Em troca, esse arremesso nunca erra."
   },
   "morningSun": {
-    "name": "Morning Sun"
+    "name": "Morning Sun",
+    "effect": "O usuário se banha nos agradáveis raios de sol, restaurando metade de seus PS máximos. Sob sol forte, dois terços de seus PS máximos são restaurados. Em todas as outras condições climáticas, um quarto de seus PS máximos é restaurado."
   },
   "synthesis": {
-    "name": "Synthesis"
+    "name": "Synthesis",
+    "effect": "O usuário produz energia por meio da fotossíntese, restaurando metade de seus PS máximos. Sob sol forte, dois terços de seus PS máximos são restaurados. Em todas as outras condições climáticas, um quarto de seus PS máximos é restaurado."
   },
   "moonlight": {
-    "name": "Moonlight"
+    "name": "Moonlight",
+    "effect": "O usuário se banha na luz reconfortante da lua, restaurando metade de seus PS máximos. Sob sol forte, dois terços de seus PS máximos são restaurados. Em todas as outras condições climáticas, um quarto de seus PS máximos é restaurado."
   },
   "hiddenPower": {
     "name": "Hidden Power",
     "effect": "Um ataque único que varia em tipo dependendo do Pokémon que está utilizando."
   },
   "crossChop": {
-    "name": "Cross Chop"
+    "name": "Cross Chop",
+    "effect": "O usuário desfere um golpe duplo com os antebraços cruzados. A taxa de golpe crítico deste movimento é aumentada em 1 estágio."
   },
   "twister": {
-    "name": "Twister"
+    "name": "Twister",
+    "effect": "O usuário levanta um tornado feroz para dilacerar os Pokémon adversários. Este movimento tem 20% de chance de fazer os alvos hesitarem e também pode atingir um alvo que esteja no ar por Fly, Bounce ou Sky Drop com o dobro do poder."
   },
   "rainDance": {
-    "name": "Rain Dance"
+    "name": "Rain Dance",
+    "effect": "O usuário invoca uma chuva forte que cai por 5 turnos, potencializando em 50% os movimentos do tipo Água. A chuva também reduz pela metade o dano causado por movimentos do tipo Fogo."
   },
   "sunnyDay": {
-    "name": "Sunny Day"
+    "name": "Sunny Day",
+    "effect": "O usuário intensifica o sol por 5 turnos, potencializando em 50% os movimentos do tipo Fogo. A luz solar também reduz pela metade o dano causado por movimentos do tipo Água."
   },
   "crunch": {
-    "name": "Crunch"
+    "name": "Crunch",
+    "effect": "O usuário tritura o alvo com presas afiadas. Este movimento tem 20% de chance de reduzir o atributo de Defesa do alvo."
   },
   "mirrorCoat": {
-    "name": "Mirror Coat"
+    "name": "Mirror Coat",
+    "effect": "Um ataque de retaliação que revida qualquer movimento especial, causando o dobro do dano recebido."
   },
   "psychUp": {
     "name": "Psych Up",
@@ -798,128 +980,160 @@
     "effect": "O usuário ataca o alvo com uma velocidade impressionante. Este movimento sempre ocorre primeiro."
   },
   "ancientPower": {
-    "name": "Ancient Power"
+    "name": "Ancient Power",
+    "effect": "O usuário ataca com um poder pré-histórico. Isso tem 10% de chance de aumentar de uma só vez os atributos de Ataque, Defesa, Ataque Especial, Defesa Especial e Velocidade do usuário."
   },
   "shadowBall": {
-    "name": "Shadow Ball"
+    "name": "Shadow Ball",
+    "effect": "O usuário ataca arremessando uma massa sombria no alvo. Este movimento tem 20% de chance de reduzir o atributo de Defesa Especial do alvo."
   },
   "futureSight": {
-    "name": "Future Sight"
+    "name": "Future Sight",
+    "effect": "2 turnos após o uso deste movimento, um bloco de energia psíquica ataca o alvo."
   },
   "rockSmash": {
-    "name": "Rock Smash"
+    "name": "Rock Smash",
+    "effect": "O usuário ataca com um soco. Este movimento tem 50% de chance de reduzir o atributo de Defesa do alvo."
   },
   "whirlpool": {
-    "name": "Whirlpool"
+    "name": "Whirlpool",
+    "effect": "O usuário prende o alvo dentro de um redemoinho violento e giratório. Por 4 a 5 turnos, o alvo recebe dano igual a um oitavo de seus PS máximos ao final de cada turno. O poder deste movimento é duplicado contra alvos submersos por Dive."
   },
   "beatUp": {
-    "name": "Beat Up"
+    "name": "Beat Up",
+    "effect": "O usuário faz todos os Pokémon da equipe atacarem o alvo, atacando tantas vezes quanto o número de Pokémon saudáveis na equipe do usuário. O poder deste movimento é calculado com base nos atributos de Ataque dos Pokémon da equipe."
   },
   "fakeOut": {
-    "name": "Fake Out"
+    "name": "Fake Out",
+    "effect": "Este ataque acerta primeiro e faz o alvo hesitar. Ele só funciona no primeiro turno cada vez que o usuário entra na batalha."
   },
   "uproar": {
-    "name": "Uproar"
+    "name": "Uproar",
+    "effect": "O usuário ataca em alvoroço por 3 turnos. Durante esse tempo, nenhum Pokémon pode adormecer."
   },
   "stockpile": {
-    "name": "Stockpile"
+    "name": "Stockpile",
+    "effect": "O usuário eleva seu nível de Estocagem em 1 e aumenta seus atributos de Defesa e Defesa Especial. Este movimento pode ser usado até 3 vezes."
   },
   "spitUp": {
-    "name": "Spit Up"
+    "name": "Spit Up",
+    "effect": "Os níveis armazenados usando o movimento Stockpile são liberados de uma só vez em um ataque. Quanto mais poder estiver armazenado, maior o poder do movimento (variando entre 100 e 300)."
   },
   "swallow": {
-    "name": "Swallow"
+    "name": "Swallow",
+    "effect": "Os níveis armazenados usando o movimento Stockpile são absorvidos pelo usuário para restaurar seus PS. Nível 1: um quarto dos PS máximos do usuário é restaurado. Nível 2: metade dos PS máximos do usuário é restaurada. Nível 3: os PS do usuário são totalmente restaurados."
   },
   "heatWave": {
-    "name": "Heat Wave"
+    "name": "Heat Wave",
+    "effect": "O usuário ataca exalando um bafo quente nos Pokémon adversários. Este movimento tem 10% de chance de causar queimadura nos alvos."
   },
   "hail": {
-    "name": "Hail"
+    "name": "Hail",
+    "effect": "O usuário invoca uma tempestade de granizo que dura 5 turnos. Todos os Pokémon, exceto os tipos Gelo, recebem dano igual a um dezesseis avos de seus PS máximos ao final de cada turno."
   },
   "torment": {
     "name": "Torment",
     "effect": "O usuário atormenta o alvo, fazendo-o incapaz de usar o mesmo movimento duas vezes seguidas."
   },
   "flatter": {
-    "name": "Flatter"
+    "name": "Flatter",
+    "effect": "Lisonja é usada para confundir o alvo. No entanto, isso também aumenta o atributo de Ataque Especial do alvo."
   },
   "willOWisp": {
     "name": "Will-O-Wisp",
     "effect": "O usuário atira uma sinistra chama azulada no alvo para causar uma queimadura."
   },
   "memento": {
-    "name": "Memento"
+    "name": "Memento",
+    "effect": "O usuário desmaia. Em troca, os atributos de Ataque e Ataque Especial do alvo são reduzidos duramente."
   },
   "facade": {
-    "name": "Facade"
+    "name": "Facade",
+    "effect": "O poder deste movimento é duplicado se o usuário estiver envenenado, gravemente envenenado, queimado ou paralisado. Embora este seja um movimento físico, o dano que ele causa não é reduzido pela metade quando o usuário está queimado."
   },
   "focusPunch": {
-    "name": "Focus Punch"
+    "name": "Focus Punch",
+    "effect": "O usuário se move por último para concentrar sua mente antes de desferir um soco. Este movimento falha se o usuário for atingido antes de usar o movimento."
   },
   "smellingSalts": {
     "name": "Smelling Salts",
     "effect": "Esse ataque causa o dobro do dano em um alvo paralisado. Entretanto, isso também cura a paralisia do alvo."
   },
   "followMe": {
-    "name": "Follow Me"
+    "name": "Follow Me",
+    "effect": "O usuário chama a atenção para si mesmo, fazendo com que todos os Pokémon adversários mirem apenas no usuário."
   },
   "naturePower": {
-    "name": "Nature Power"
+    "name": "Nature Power",
+    "effect": "Este ataque faz uso do poder da natureza. Seus efeitos variam dependendo do bioma ou terreno em que este movimento foi usado."
   },
   "charge": {
-    "name": "Charge"
+    "name": "Charge",
+    "effect": "O usuário fica carregado, duplicando o poder do próximo movimento do tipo Elétrico que usar. Isso também aumenta o atributo de Defesa Especial do usuário."
   },
   "taunt": {
-    "name": "Taunt"
+    "name": "Taunt",
+    "effect": "O alvo é provocado a uma fúria que só lhe permite usar movimentos de ataque por 3 turnos."
   },
   "helpingHand": {
-    "name": "Helping Hand"
+    "name": "Helping Hand",
+    "effect": "O usuário auxilia um aliado aumentando em 50% o poder do ataque desse aliado."
   },
   "trick": {
-    "name": "Trick"
+    "name": "Trick",
+    "effect": "O usuário pega o alvo desprevenido e troca um item segurado do alvo pelo seu próprio."
   },
   "rolePlay": {
     "name": "Role Play",
     "effect": "O usuário imita o alvo completamente, copiando a Habilidade natural do alvo."
   },
   "wish": {
-    "name": "Wish"
+    "name": "Wish",
+    "effect": "Um turno após o uso deste movimento, os PS do usuário ou de seu substituto são restaurados em metade dos PS máximos do usuário."
   },
   "assist": {
     "name": "Assist",
     "effect": "O usuário na pressa usa aleatoriamente um dos movimentos conhecidos pelos outros Pokémon na equipe."
   },
   "ingrain": {
-    "name": "Ingrain"
+    "name": "Ingrain",
+    "effect": "O usuário lança raízes que restauram seus próprios PS a cada turno. Como o usuário agora está enraizado, ele não pode fugir nem ser trocado."
   },
   "superpower": {
-    "name": "Superpower"
+    "name": "Superpower",
+    "effect": "O usuário ataca o alvo com grande poder. Isso também reduz os atributos de Ataque e Defesa do usuário."
   },
   "magicCoat": {
-    "name": "Magic Coat"
+    "name": "Magic Coat",
+    "effect": "Até o fim do turno, certos movimentos que não causam dano direcionados ao usuário são bloqueados por uma barreira e refletidos de volta contra quem os usou."
   },
   "recycle": {
     "name": "Recycle",
     "effect": "O usuário recicla um item segurado que já foi usado em batalha para que possa ser usado de novo."
   },
   "revenge": {
-    "name": "Revenge"
+    "name": "Revenge",
+    "effect": "O usuário se move por último. O poder deste movimento é duplicado se o alvo tiver causado dano ao usuário no mesmo turno."
   },
   "brickBreak": {
-    "name": "Brick Break"
+    "name": "Brick Break",
+    "effect": "O usuário ataca com um golpe veloz. Este movimento também pode quebrar barreiras como Light Screen, Reflect e Aurora Veil."
   },
   "yawn": {
     "name": "Yawn",
     "effect": "O usuário dá um grande e preguiçoso bocejo que acalma o alvo, fazendo-o cair no sono no próximo turno."
   },
   "knockOff": {
-    "name": "Knock Off"
+    "name": "Knock Off",
+    "effect": "O usuário derruba um item segurado do alvo, removendo o item. O poder deste movimento é aumentado em 50% se o alvo estiver segurando um item."
   },
   "endeavor": {
-    "name": "Endeavor"
+    "name": "Endeavor",
+    "effect": "O usuário causa dano reduzindo os PS do alvo para aproximadamente os mesmos PS do usuário. Isso falha se os PS do alvo forem iguais ou menores que os do usuário. Pokémon Chefe são imunes a este movimento."
   },
   "eruption": {
-    "name": "Eruption"
+    "name": "Eruption",
+    "effect": "O usuário ataca os Pokémon adversários com fúria explosiva. Quanto menos PS o usuário tiver, menor o poder deste movimento (variando entre 1 e 150)."
   },
   "skillSwap": {
     "name": "Skill Swap",
@@ -942,56 +1156,72 @@
     "effect": "O usuário rouba o efeito de qualquer tentativa de usar um movimento de cura ou mudança de atributo."
   },
   "secretPower": {
-    "name": "Secret Power"
+    "name": "Secret Power",
+    "effect": "Os efeitos adicionais deste ataque dependem do bioma ou terreno em que foi usado."
   },
   "dive": {
-    "name": "Dive"
+    "name": "Dive",
+    "effect": "O usuário mergulha no primeiro turno, então emerge e ataca no turno seguinte."
   },
   "armThrust": {
-    "name": "Arm Thrust"
+    "name": "Arm Thrust",
+    "effect": "O usuário ataca o alvo com golpes de braço de palma aberta. Este movimento atinge de duas a cinco vezes seguidas."
   },
   "camouflage": {
-    "name": "Camouflage"
+    "name": "Camouflage",
+    "effect": "O tipo do usuário muda dependendo do bioma ou terreno em que este movimento foi usado."
   },
   "tailGlow": {
-    "name": "Tail Glow"
+    "name": "Tail Glow",
+    "effect": "O usuário emite luzes brilhantes enquanto concentra sua mente, aumentando drasticamente seu atributo de Ataque Especial."
   },
   "lusterPurge": {
-    "name": "Luster Purge"
+    "name": "Luster Purge",
+    "effect": "O usuário libera uma explosão de luz danificante. Este movimento tem 50% de chance de reduzir o atributo de Defesa Especial do alvo."
   },
   "mistBall": {
-    "name": "Mist Ball"
+    "name": "Mist Ball",
+    "effect": "O usuário ataca com uma bola repleta de penugem semelhante a névoa. Este movimento tem 50% de chance de reduzir o atributo de Ataque Especial do alvo."
   },
   "featherDance": {
     "name": "Feather Dance",
     "effect": "O usuário cobre o corpo do alvo com uma grande massa de penas que prejudicam duramente o Ataque do alvo."
   },
   "teeterDance": {
-    "name": "Teeter Dance"
+    "name": "Teeter Dance",
+    "effect": "O usuário realiza uma dança cambaleante que confunde todos os Pokémon ao seu redor."
   },
   "blazeKick": {
-    "name": "Blaze Kick"
+    "name": "Blaze Kick",
+    "effect": "O usuário ataca com um chute que tem 10% de chance de causar queimadura no alvo. A taxa de golpe crítico deste movimento é aumentada em 1 estágio."
   },
   "mudSport": {
-    "name": "Mud Sport"
+    "name": "Mud Sport",
+    "effect": "O usuário levanta lama no campo de batalha. Isso enfraquece os movimentos do tipo Elétrico por 5 turnos."
   },
   "iceBall": {
-    "name": "Ice Ball"
+    "name": "Ice Ball",
+    "effect": "O usuário rola continuamente contra o alvo ao longo de 5 turnos. Este ataque duplica seu poder a cada acerto e se reinicia após 5 turnos ou se o movimento for interrompido."
   },
   "needleArm": {
-    "name": "Needle Arm"
+    "name": "Needle Arm",
+    "effect": "O usuário ataca balançando descontroladamente seus braços espinhosos. Este movimento tem 30% de chance de fazer o alvo hesitar."
   },
   "slackOff": {
-    "name": "Slack Off"
+    "name": "Slack Off",
+    "effect": "O usuário relaxa, restaurando metade de seus PS máximos."
   },
   "hyperVoice": {
-    "name": "Hyper Voice"
+    "name": "Hyper Voice",
+    "effect": "O usuário ataca soltando um grito horrivelmente alto e retumbante."
   },
   "poisonFang": {
-    "name": "Poison Fang"
+    "name": "Poison Fang",
+    "effect": "O usuário morde o alvo com presas tóxicas. Este movimento tem 50% de chance de envenenar gravemente o alvo."
   },
   "crushClaw": {
-    "name": "Crush Claw"
+    "name": "Crush Claw",
+    "effect": "O usuário dilacera o alvo com garras duras e afiadas. Este movimento tem 50% de chance de reduzir o atributo de Defesa do alvo."
   },
   "blastBurn": {
     "name": "Blast Burn",
@@ -1002,36 +1232,44 @@
     "effect": "O alvo é acertado por uma explosão aquática. O usuário não pode se mover no próximo turno."
   },
   "meteorMash": {
-    "name": "Meteor Mash"
+    "name": "Meteor Mash",
+    "effect": "O alvo é atingido por um soco forte disparado como um meteoro. Este movimento tem 20% de chance de aumentar o atributo de Ataque do usuário."
   },
   "astonish": {
-    "name": "Astonish"
+    "name": "Astonish",
+    "effect": "O usuário ataca o alvo gritando de uma forma assustadora. Este movimento tem 30% de chance de fazer o alvo hesitar."
   },
   "weatherBall": {
-    "name": "Weather Ball"
+    "name": "Weather Ball",
+    "effect": "O tipo e o poder deste movimento mudam dependendo do clima no momento em que o movimento é usado."
   },
   "aromatherapy": {
     "name": "Aromatherapy",
     "effect": "O usuário libera um aroma calmante para curar as condições de status de todos os seus companheiros Pokémon e aliados."
   },
   "fakeTears": {
-    "name": "Fake Tears"
+    "name": "Fake Tears",
+    "effect": "O usuário finge chorar para desconcertar o alvo. Isso reduz duramente o atributo de Defesa Especial do alvo."
   },
   "airCutter": {
-    "name": "Air Cutter"
+    "name": "Air Cutter",
+    "effect": "O usuário lança um vento afiado como navalha para cortar os Pokémon adversários. A taxa de golpe crítico deste movimento é aumentada em 1 estágio."
   },
   "overheat": {
-    "name": "Overheat"
+    "name": "Overheat",
+    "effect": "O usuário ataca o alvo com toda a sua força. O recuo deste movimento reduz duramente o atributo de Ataque Especial do usuário."
   },
   "odorSleuth": {
     "name": "Odor Sleuth",
     "effect": "Permite que um alvo do tipo Fantasma seja atingido por ataques do tipo Normal e Lutador. Isso também permite que um alvo evasivo seja acertado."
   },
   "rockTomb": {
-    "name": "Rock Tomb"
+    "name": "Rock Tomb",
+    "effect": "O usuário arremessa pedregulhos no alvo para causar dano. Isso também reduz o atributo de Velocidade do alvo ao restringir seus movimentos."
   },
   "silverWind": {
-    "name": "Silver Wind"
+    "name": "Silver Wind",
+    "effect": "O alvo é atacado com escamas em pó sopradas pelo vento. Isso também tem 10% de chance de aumentar de uma só vez os atributos de Ataque, Defesa, Ataque Especial, Defesa Especial e Velocidade do usuário."
   },
   "metalSound": {
     "name": "Metal Sound",
@@ -1042,119 +1280,148 @@
     "effect": "O usuário toca uma agradável melodia que acalma o alvo, fazendo-o entrar em sono profundo."
   },
   "tickle": {
-    "name": "Tickle"
+    "name": "Tickle",
+    "effect": "O usuário faz cócegas no alvo até ele rir, reduzindo seus atributos de Ataque e Defesa."
   },
   "cosmicPower": {
-    "name": "Cosmic Power"
+    "name": "Cosmic Power",
+    "effect": "O usuário absorve um poder místico do espaço para aumentar seus atributos de Defesa e Defesa Especial."
   },
   "waterSpout": {
-    "name": "Water Spout"
+    "name": "Water Spout",
+    "effect": "O usuário jorra água para causar dano aos Pokémon adversários. Quanto menos PS o usuário tiver, menor o poder deste movimento (variando entre 1 e 150)."
   },
   "signalBeam": {
-    "name": "Signal Beam"
+    "name": "Signal Beam",
+    "effect": "O usuário ataca com um sinistro feixe de luz. Este movimento tem 10% de chance de confundir o alvo."
   },
   "shadowPunch": {
     "name": "Shadow Punch",
     "effect": "O usuário dispara um soco dentre as sombras. Esse ataque nunca erra."
   },
   "extrasensory": {
-    "name": "Extrasensory"
+    "name": "Extrasensory",
+    "effect": "O usuário ataca com um poder estranho e invisível. Este movimento tem 10% de chance de fazer o alvo hesitar."
   },
   "skyUppercut": {
-    "name": "Sky Uppercut"
+    "name": "Sky Uppercut",
+    "effect": "O usuário ataca o alvo com um uppercut desferido com força em direção ao céu. Este movimento também pode atingir um alvo que esteja no ar por Fly, Bounce ou Sky Drop."
   },
   "sandTomb": {
-    "name": "Sand Tomb"
+    "name": "Sand Tomb",
+    "effect": "O usuário prende o alvo dentro de uma tempestade de areia furiosa. Por 4 a 5 turnos, o alvo recebe dano igual a um oitavo de seus PS máximos ao final de cada turno."
   },
   "sheerCold": {
-    "name": "Sheer Cold"
+    "name": "Sheer Cold",
+    "effect": "O alvo é atacado com uma rajada de frio de zero absoluto. O alvo desmaia instantaneamente se este ataque acertar, a menos que seja um Pokémon Chefe. Este movimento não afeta os tipos Gelo. A precisão deste movimento é fixada em 30%. Se usado por Pokémon que não sejam do tipo Gelo, a precisão deste movimento é de 20%."
   },
   "muddyWater": {
-    "name": "Muddy Water"
+    "name": "Muddy Water",
+    "effect": "O usuário ataca disparando água lamacenta nos Pokémon adversários. Este movimento tem 30% de chance de reduzir a Precisão deles."
   },
   "bulletSeed": {
-    "name": "Bullet Seed"
+    "name": "Bullet Seed",
+    "effect": "O usuário ataca disparando sementes com força no alvo. Este movimento atinge de duas a cinco vezes seguidas."
   },
   "aerialAce": {
     "name": "Aerial Ace",
     "effect": "O usuário confunde o alvo com velocidade e, em seguida, dá um golpe. Este ataque nunca falha."
   },
   "icicleSpear": {
-    "name": "Icicle Spear"
+    "name": "Icicle Spear",
+    "effect": "O usuário ataca lançando estalactites afiadas no alvo. Este movimento atinge de duas a cinco vezes seguidas."
   },
   "ironDefense": {
-    "name": "Iron Defense"
+    "name": "Iron Defense",
+    "effect": "O usuário endurece a superfície de seu corpo como ferro, aumentando bruscamente seu atributo de Defesa."
   },
   "block": {
-    "name": "Block"
+    "name": "Block",
+    "effect": "O usuário bloqueia o caminho do alvo com os braços bem abertos para impedir que o alvo fuja ou seja trocado da batalha."
   },
   "howl": {
-    "name": "Howl"
+    "name": "Howl",
+    "effect": "O usuário uiva alto para animar a si mesmo e seus aliados. Isso aumenta os atributos de Ataque deles."
   },
   "dragonClaw": {
-    "name": "Dragon Claw"
+    "name": "Dragon Claw",
+    "effect": "O usuário dilacera o alvo com garras enormes e afiadas para causar dano."
   },
   "frenzyPlant": {
     "name": "Frenzy Plant",
     "effect": "O usuário esmaga o alvo com uma enorme árvore. O usuário não pode se mover no próximo turno."
   },
   "bulkUp": {
-    "name": "Bulk Up"
+    "name": "Bulk Up",
+    "effect": "O usuário tensiona os músculos para reforçar seu corpo, aumentando seus atributos de Ataque e Defesa."
   },
   "bounce": {
-    "name": "Bounce"
+    "name": "Bounce",
+    "effect": "O usuário salta bem alto no primeiro turno e então cai sobre o alvo no turno seguinte. Este movimento tem 30% de chance de paralisar o alvo."
   },
   "mudShot": {
     "name": "Mud Shot",
     "effect": "O usuário ataca lançando um pedaço de lama no alvo. Isso também reduz o atributo de Velocidade do alvo."
   },
   "poisonTail": {
-    "name": "Poison Tail"
+    "name": "Poison Tail",
+    "effect": "O usuário golpeia o alvo com sua cauda. A taxa de golpe crítico deste movimento é aumentada em 1 estágio e ele tem 10% de chance de envenenar o alvo."
   },
   "covet": {
     "name": "Covet",
     "effect": "O usuário se aproxima do alvo de forma amigável e tenta roubá-lo. Este movimento tem 30% de chance de roubar um dos itens que o alvo está segurando."
   },
   "voltTackle": {
-    "name": "Volt Tackle"
+    "name": "Volt Tackle",
+    "effect": "O usuário se eletrifica e investe contra o alvo para causar dano. O usuário recebe um terço do dano causado por este movimento. Isso também tem 10% de chance de paralisar o alvo."
   },
   "magicalLeaf": {
     "name": "Magical Leaf",
     "effect": "O usuário espalha folhas peculiares que perseguem o alvo. Esse ataque nunca erra."
   },
   "waterSport": {
-    "name": "Water Sport"
+    "name": "Water Sport",
+    "effect": "O usuário encharca o campo de batalha com água. Isso enfraquece os movimentos do tipo Fogo por 5 turnos."
   },
   "calmMind": {
-    "name": "Calm Mind"
+    "name": "Calm Mind",
+    "effect": "O usuário concentra silenciosamente sua mente e acalma seu espírito para aumentar seus atributos de Ataque Especial e Defesa Especial."
   },
   "leafBlade": {
-    "name": "Leaf Blade"
+    "name": "Leaf Blade",
+    "effect": "O usuário maneja uma folha afiada como uma espada e corta o alvo para causar dano. A taxa de golpe crítico deste movimento é aumentada em 1 estágio."
   },
   "dragonDance": {
-    "name": "Dragon Dance"
+    "name": "Dragon Dance",
+    "effect": "O usuário realiza vigorosamente uma dança mística e poderosa que aumenta seus atributos de Ataque e Velocidade."
   },
   "rockBlast": {
-    "name": "Rock Blast"
+    "name": "Rock Blast",
+    "effect": "O usuário ataca arremessando rochas duras no alvo. Este movimento atinge de duas a cinco vezes seguidas."
   },
   "shockWave": {
     "name": "Shock Wave",
     "effect": "O usuário atinge o alvo com um repentino ataque de eletricidade. Esse ataque nunca erra."
   },
   "waterPulse": {
-    "name": "Water Pulse"
+    "name": "Water Pulse",
+    "effect": "O usuário ataca o alvo com uma pulsante rajada de água. Este movimento tem 20% de chance de confundir o alvo."
   },
   "doomDesire": {
-    "name": "Doom Desire"
+    "name": "Doom Desire",
+    "effect": "2 turnos após o uso deste movimento, um feixe concentrado de luz atinge o alvo."
   },
   "psychoBoost": {
-    "name": "Psycho Boost"
+    "name": "Psycho Boost",
+    "effect": "O usuário ataca o alvo com toda a sua força. O recuo deste movimento reduz duramente o atributo de Ataque Especial do usuário."
   },
   "roost": {
-    "name": "Roost"
+    "name": "Roost",
+    "effect": "O usuário pousa e descansa seu corpo, restaurando metade de seus PS máximos. Se o usuário for do tipo Voador, ele perderá o tipo Voador durante o turno."
   },
   "gravity": {
-    "name": "Gravity"
+    "name": "Gravity",
+    "effect": "Aumenta a precisão dos movimentos em 67% e traz para o chão Pokémon como os tipos Voadores ou os que têm a Habilidade Levitate por 5 turnos. Movimentos que envolvem voar não podem ser usados."
   },
   "miracleEye": {
     "name": "Miracle Eye",
@@ -1165,68 +1432,84 @@
     "effect": "Esse ataque causa muito dano em um alvo que estiver dormindo; entretanto, isso também acorda o alvo."
   },
   "hammerArm": {
-    "name": "Hammer Arm"
+    "name": "Hammer Arm",
+    "effect": "O usuário desfere seu punho forte e pesado contra o alvo para causar dano. Isso também reduz o atributo de Velocidade do usuário."
   },
   "gyroBall": {
-    "name": "Gyro Ball"
+    "name": "Gyro Ball",
+    "effect": "O usuário investe contra o alvo com um giro em alta velocidade. Quanto mais lento o usuário for em relação ao alvo, maior o poder do movimento (variando entre 1 e 150)."
   },
   "healingWish": {
     "name": "Healing Wish",
     "effect": "O usuário desmaia. Em troca, o Pokémon que o substitui terá seus PS restaurados e suas condições de status curadas."
   },
   "brine": {
-    "name": "Brine"
+    "name": "Brine",
+    "effect": "O poder deste movimento é duplicado se os PS do alvo estiverem pela metade ou menos."
   },
   "naturalGift": {
-    "name": "Natural Gift"
+    "name": "Natural Gift",
+    "effect": "O usuário obtém poder para atacar usando uma Fruta segurada. A Fruta determina o tipo e o poder do movimento."
   },
   "feint": {
-    "name": "Feint"
+    "name": "Feint",
+    "effect": "Este movimento pode atingir um alvo que esteja usando um movimento como Protect ou Detect e remove os efeitos desses movimentos."
   },
   "pluck": {
-    "name": "Pluck"
+    "name": "Pluck",
+    "effect": "O usuário ataca bicando o alvo. Se o alvo estiver segurando uma Fruta, o usuário a come e ganha seu efeito."
   },
   "tailwind": {
-    "name": "Tailwind"
+    "name": "Tailwind",
+    "effect": "O usuário levanta um redemoinho turbulento que duplica os atributos de Velocidade de si mesmo e de seus aliados por 4 turnos."
   },
   "acupressure": {
     "name": "Acupressure",
     "effect": "O usuário aplica pressão em pontos de estresse, bruscamente fortalecendo um de seus atributos ou de seus aliados."
   },
   "metalBurst": {
-    "name": "Metal Burst"
+    "name": "Metal Burst",
+    "effect": "O usuário revida para causar 1,5 vez o dano que recebeu do movimento de um oponente durante o turno em que este movimento é usado."
   },
   "uTurn": {
     "name": "U-turn",
     "effect": "Depois de fazer o seu ataque, o usuário corre de volta para trocar de lugar com um Pokémon da própria equipe."
   },
   "closeCombat": {
-    "name": "Close Combat"
+    "name": "Close Combat",
+    "effect": "O usuário luta corpo a corpo com o alvo, causando dano sem se defender. Isso também reduz os atributos de Defesa e Defesa Especial do usuário."
   },
   "payback": {
-    "name": "Payback"
+    "name": "Payback",
+    "effect": "O usuário armazena poder e então ataca. O poder deste movimento é duplicado se o usuário se mover depois do alvo."
   },
   "assurance": {
-    "name": "Assurance"
+    "name": "Assurance",
+    "effect": "O poder deste movimento é duplicado se o alvo já tiver recebido algum dano no mesmo turno."
   },
   "embargo": {
-    "name": "Embargo"
+    "name": "Embargo",
+    "effect": "Este movimento impede o alvo de usar seus itens segurados por 5 turnos."
   },
   "fling": {
-    "name": "Fling"
+    "name": "Fling",
+    "effect": "O usuário arremessa um de seus itens segurados no alvo para atacar. O poder e os efeitos deste movimento dependem do item."
   },
   "psychoShift": {
     "name": "Psycho Shift",
     "effect": "Usando seu poder psíquico de sugestão, o usuário transfere suas condições de status para o alvo."
   },
   "trumpCard": {
-    "name": "Trump Card"
+    "name": "Trump Card",
+    "effect": "O poder deste movimento começa em 40 e aumenta conforme seus PP restantes diminuem: 50 com 4 PP, 60 com 3 PP, 80 com 2 PP e 200 com 1 PP. Este movimento nunca erra."
   },
   "healBlock": {
-    "name": "Heal Block"
+    "name": "Heal Block",
+    "effect": "Por 5 turnos, o usuário impede a equipe adversária de usar quaisquer movimentos, Habilidades ou itens segurados que recuperem PS."
   },
   "wringOut": {
-    "name": "Wring Out"
+    "name": "Wring Out",
+    "effect": "O usuário torce o alvo com força. Quanto mais PS o alvo tiver, maior o poder do movimento (variando entre 1 e 120)."
   },
   "powerTrick": {
     "name": "Power Trick",
@@ -1237,13 +1520,16 @@
     "effect": "O usuário arremessa os ácidos de seu estômago no alvo. O fluido elimina o efeito da habilidade do alvo."
   },
   "luckyChant": {
-    "name": "Lucky Chant"
+    "name": "Lucky Chant",
+    "effect": "O usuário entoa um encantamento em direção ao céu, impedindo que os Pokémon adversários acertem golpes críticos por 5 turnos."
   },
   "meFirst": {
-    "name": "Me First"
+    "name": "Me First",
+    "effect": "O usuário se antecipa ao alvo para copiar e usar o movimento pretendido pelo alvo, aumentando seu poder em 50%. Este movimento falha se não for usado primeiro."
   },
   "copycat": {
-    "name": "Copycat"
+    "name": "Copycat",
+    "effect": "O usuário imita o último movimento que foi usado. Este movimento falha se nenhum outro movimento tiver sido usado ainda ou se o último movimento usado não puder ser copiado."
   },
   "powerSwap": {
     "name": "Power Swap",
@@ -1254,7 +1540,8 @@
     "effect": "O usuário usufrui de seu poder psíquico para trocar mudanças de atributos feitas à sua Defesa e Defesa Especial com as do alvo."
   },
   "punishment": {
-    "name": "Punishment"
+    "name": "Punishment",
+    "effect": "O poder deste movimento é aumentado em 20 para cada estágio em que os atributos do alvo tenham sido aumentados."
   },
   "lastResort": {
     "name": "Last Resort",
@@ -1269,7 +1556,8 @@
     "effect": "Esse movimento permite que o usuário ataque primeiro. Esse ataque falha caso o alvo não esteja preparando um ataque."
   },
   "toxicSpikes": {
-    "name": "Toxic Spikes"
+    "name": "Toxic Spikes",
+    "effect": "O usuário arma uma armadilha de espinhos venenosos aos pés da equipe adversária. Uma camada envenenará os Pokémon adversários que entrarem na batalha, enquanto uma segunda camada os envenenará gravemente. Tipos Voadores ou Pokémon com Levitate não são afetados. Tipos Venenosos que pisarem nesses espinhos irão absorvê-los e removê-los do campo."
   },
   "heartSwap": {
     "name": "Heart Swap",
@@ -1280,324 +1568,408 @@
     "effect": "O usuário envolve-se em um véu feito de água. Ele recupera um pouco de PS a cada turno."
   },
   "magnetRise": {
-    "name": "Magnet Rise"
+    "name": "Magnet Rise",
+    "effect": "O usuário levita usando magnetismo gerado eletricamente por 5 turnos."
   },
   "flareBlitz": {
-    "name": "Flare Blitz"
+    "name": "Flare Blitz",
+    "effect": "O usuário se envolve em fogo e investe contra o alvo para causar dano. O usuário recebe um terço do dano causado por este movimento. Isso também tem 10% de chance de causar queimadura no alvo e descongela o usuário caso ele esteja congelado."
   },
   "forcePalm": {
-    "name": "Force Palm"
+    "name": "Force Palm",
+    "effect": "O alvo é atacado com uma onda de choque. Este movimento tem 30% de chance de paralisar o alvo."
   },
   "auraSphere": {
-    "name": "Aura Sphere"
+    "name": "Aura Sphere",
+    "effect": "O usuário libera um pulso de poder de aura das profundezas de seu corpo no alvo. Este ataque nunca erra."
   },
   "rockPolish": {
-    "name": "Rock Polish"
+    "name": "Rock Polish",
+    "effect": "O usuário pole seu corpo para reduzir a resistência do ar. Isso aumenta bruscamente o atributo de Velocidade do usuário."
   },
   "poisonJab": {
-    "name": "Poison Jab"
+    "name": "Poison Jab",
+    "effect": "O alvo é perfurado por um tentáculo, um braço ou algo do tipo impregnado de veneno. Este movimento tem 30% de chance de envenenar o alvo."
   },
   "darkPulse": {
-    "name": "Dark Pulse"
+    "name": "Dark Pulse",
+    "effect": "O usuário libera uma aura horrível impregnada de más intenções. Este movimento tem 20% de chance de fazer o alvo hesitar."
   },
   "nightSlash": {
-    "name": "Night Slash"
+    "name": "Night Slash",
+    "effect": "O usuário dilacera o alvo no instante em que surge uma oportunidade. A taxa de golpe crítico deste movimento é aumentada em 1 estágio."
   },
   "aquaTail": {
     "name": "Aqua Tail",
     "effect": "O usuário ataca balançando sua cauda como se fosse uma violenta e furiosa tempestade."
   },
   "seedBomb": {
-    "name": "Seed Bomb"
+    "name": "Seed Bomb",
+    "effect": "O usuário ataca despejando de cima uma saraivada de sementes de casca dura sobre o alvo."
   },
   "airSlash": {
-    "name": "Air Slash"
+    "name": "Air Slash",
+    "effect": "O usuário ataca com uma lâmina de ar que corta até o céu. Este movimento tem 30% de chance de fazer o alvo hesitar."
   },
   "xScissor": {
-    "name": "X-Scissor"
+    "name": "X-Scissor",
+    "effect": "O usuário corta o alvo cruzando suas foices, garras ou algo do tipo como se fossem uma tesoura."
   },
   "bugBuzz": {
-    "name": "Bug Buzz"
+    "name": "Bug Buzz",
+    "effect": "O usuário vibra para gerar uma onda sonora danificante. Este movimento tem 10% de chance de reduzir o atributo de Defesa Especial do alvo."
   },
   "dragonPulse": {
     "name": "Dragon Pulse",
     "effect": "O alvo é atacado com uma onda de choque gerada pela boca aberta do usuário."
   },
   "dragonRush": {
-    "name": "Dragon Rush"
+    "name": "Dragon Rush",
+    "effect": "O usuário investe contra o alvo exibindo uma ameaça avassaladora. Este movimento tem 20% de chance de fazer o alvo hesitar. Se o alvo tiver usado Minimize, o poder deste movimento é duplicado e ele sempre acertará."
   },
   "powerGem": {
     "name": "Power Gem",
     "effect": "O usuário ataca com um raio de luz que brilha como se fosse feito de pedras preciosas."
   },
   "drainPunch": {
-    "name": "Drain Punch"
+    "name": "Drain Punch",
+    "effect": "O usuário ataca com um soco que drena energia. Os PS do usuário são restaurados em metade do dano causado por este movimento."
   },
   "vacuumWave": {
     "name": "Vacuum Wave",
     "effect": "O usuário rodopia seus punhos para lançar uma onda de vácuo puro no alvo. Esse movimento tem prioridade."
   },
   "focusBlast": {
-    "name": "Focus Blast"
+    "name": "Focus Blast",
+    "effect": "O usuário eleva sua concentração mental e libera seu poder. Este movimento tem 10% de chance de reduzir o atributo de Defesa Especial do alvo."
   },
   "energyBall": {
-    "name": "Energy Ball"
+    "name": "Energy Ball",
+    "effect": "O usuário extrai o poder da natureza e o dispara no alvo. Este movimento tem 10% de chance de reduzir o atributo de Defesa Especial do alvo."
   },
   "braveBird": {
-    "name": "Brave Bird"
+    "name": "Brave Bird",
+    "effect": "O usuário recolhe as asas e investe em baixa altitude. O usuário recebe um terço do dano causado por este movimento."
   },
   "earthPower": {
-    "name": "Earth Power"
+    "name": "Earth Power",
+    "effect": "O usuário faz o solo sob o alvo entrar em erupção com poder. Este movimento tem 10% de chance de reduzir o atributo de Defesa Especial do alvo."
   },
   "switcheroo": {
-    "name": "Switcheroo"
+    "name": "Switcheroo",
+    "effect": "O usuário troca um item segurado com o alvo mais rápido do que os olhos podem acompanhar."
   },
   "gigaImpact": {
     "name": "Giga Impact",
     "effect": "O usuário investe no alvo usando absolutamente todo o seu poder. O usuário não poderá se mover no próximo turno."
   },
   "nastyPlot": {
-    "name": "Nasty Plot"
+    "name": "Nasty Plot",
+    "effect": "O usuário estimula seu cérebro pensando em maldades. Isso aumenta bruscamente o atributo de Ataque Especial do usuário."
   },
   "bulletPunch": {
     "name": "Bullet Punch",
     "effect": "O usuário atinge o alvo com socos fortes tão rápidos como tiros. Esse movimento tem prioridade."
   },
   "avalanche": {
-    "name": "Avalanche"
+    "name": "Avalanche",
+    "effect": "O usuário se move por último. O poder deste movimento é duplicado se o alvo tiver causado dano ao usuário no mesmo turno."
   },
   "iceShard": {
     "name": "Ice Shard",
     "effect": "O usuário congela rapidamente cristais de gelo e os arremessa no alvo. Esse movimento tem prioridade."
   },
   "shadowClaw": {
-    "name": "Shadow Claw"
+    "name": "Shadow Claw",
+    "effect": "O usuário ataca dilacerando o alvo com uma garra afiada feita de sombras. A taxa de golpe crítico deste movimento é aumentada em 1 estágio."
   },
   "thunderFang": {
-    "name": "Thunder Fang"
+    "name": "Thunder Fang",
+    "effect": "O usuário morde com presas eletrificadas. Este movimento tem 10% de chance de paralisar o alvo e 10% de chance de fazer o alvo hesitar."
   },
   "iceFang": {
-    "name": "Ice Fang"
+    "name": "Ice Fang",
+    "effect": "O usuário morde com presas geladas. Este movimento tem 10% de chance de congelar o alvo e 10% de chance de fazer o alvo hesitar."
   },
   "fireFang": {
-    "name": "Fire Fang"
+    "name": "Fire Fang",
+    "effect": "O usuário morde com presas envoltas em chamas. Este movimento tem 10% de chance de causar queimadura no alvo e 10% de chance de fazer o alvo hesitar."
   },
   "shadowSneak": {
     "name": "Shadow Sneak",
     "effect": "O usuário estende a própria sombra e ataca o alvo por trás. Esse movimento tem prioridade."
   },
   "mudBomb": {
-    "name": "Mud Bomb"
+    "name": "Mud Bomb",
+    "effect": "O usuário lança uma bola de lama compacta para atacar. Este movimento tem 30% de chance de reduzir a Precisão do alvo."
   },
   "psychoCut": {
-    "name": "Psycho Cut"
+    "name": "Psycho Cut",
+    "effect": "O usuário rasga o alvo com lâminas formadas por poder psíquico. A taxa de golpe crítico deste movimento é aumentada em 1 estágio."
   },
   "zenHeadbutt": {
-    "name": "Zen Headbutt"
+    "name": "Zen Headbutt",
+    "effect": "O usuário concentra sua força de vontade na cabeça e ataca o alvo. Este movimento tem 20% de chance de fazer o alvo hesitar."
   },
   "mirrorShot": {
-    "name": "Mirror Shot"
+    "name": "Mirror Shot",
+    "effect": "O usuário libera um clarão de energia no alvo a partir de seu corpo polido. Este movimento tem 30% de chance de reduzir a Precisão do alvo."
   },
   "flashCannon": {
-    "name": "Flash Cannon"
+    "name": "Flash Cannon",
+    "effect": "O usuário reúne toda a sua energia luminosa e a libera de uma só vez. Este movimento tem 10% de chance de reduzir o atributo de Defesa Especial do alvo."
   },
   "rockClimb": {
-    "name": "Rock Climb"
+    "name": "Rock Climb",
+    "effect": "O usuário ataca o alvo chocando-se contra ele com uma força incrível. Este movimento tem 20% de chance de confundir o alvo."
   },
   "defog": {
-    "name": "Defog"
+    "name": "Defog",
+    "effect": "Um vento forte afasta as barreiras do alvo, como Light Screen, Reflect, Aurora Veil ou Safeguard, bem como quaisquer armadilhas ou terreno do campo. Isso também reduz a evasão do alvo e pode dissipar névoa densa."
   },
   "trickRoom": {
-    "name": "Trick Room"
+    "name": "Trick Room",
+    "effect": "O usuário se move por último e cria uma área bizarra na qual os Pokémon mais lentos se movem primeiro por 5 turnos."
   },
   "dracoMeteor": {
-    "name": "Draco Meteor"
+    "name": "Draco Meteor",
+    "effect": "Cometas são invocados do céu sobre o alvo. O recuo deste movimento reduz duramente o atributo de Ataque Especial do usuário."
   },
   "discharge": {
-    "name": "Discharge"
+    "name": "Discharge",
+    "effect": "O usuário atinge tudo ao seu redor liberando uma explosão de eletricidade. Este movimento tem 30% de chance de paralisar os alvos."
   },
   "lavaPlume": {
-    "name": "Lava Plume"
+    "name": "Lava Plume",
+    "effect": "O usuário incendeia tudo ao seu redor em um inferno de chamas escarlates. Este movimento tem 30% de chance de causar queimadura nos alvos."
   },
   "leafStorm": {
-    "name": "Leaf Storm"
+    "name": "Leaf Storm",
+    "effect": "O usuário levanta uma tempestade de folhas ao redor do alvo. O recuo deste movimento reduz duramente o atributo de Ataque Especial do usuário."
   },
   "powerWhip": {
-    "name": "Power Whip"
+    "name": "Power Whip",
+    "effect": "O usuário gira violentamente suas vinhas, tentáculos ou algo do tipo para chicotear o alvo."
   },
   "rockWrecker": {
     "name": "Rock Wrecker",
     "effect": "O usuário lança uma grande rocha no alvo. O usuário não pode se mover no próximo turno."
   },
   "crossPoison": {
-    "name": "Cross Poison"
+    "name": "Cross Poison",
+    "effect": "Um ataque cortante com uma lâmina venenosa que tem 10% de chance de envenenar o alvo. A taxa de golpe crítico deste movimento é aumentada em 1 estágio."
   },
   "gunkShot": {
-    "name": "Gunk Shot"
+    "name": "Gunk Shot",
+    "effect": "O usuário dispara lixo imundo no alvo para atacar. Este movimento tem 30% de chance de envenenar o alvo."
   },
   "ironHead": {
-    "name": "Iron Head"
+    "name": "Iron Head",
+    "effect": "O usuário golpeia o alvo com sua cabeça dura como aço. Este movimento tem 20% de chance de fazer o alvo hesitar."
   },
   "magnetBomb": {
     "name": "Magnet Bomb",
     "effect": "O usuário lança bombas de aço que grudam no alvo. Esse ataque nunca erra."
   },
   "stoneEdge": {
-    "name": "Stone Edge"
+    "name": "Stone Edge",
+    "effect": "O usuário perfura o alvo com pedras afiadas. A taxa de golpe crítico deste movimento é aumentada em 1 estágio."
   },
   "captivate": {
     "name": "Captivate",
     "effect": "Se algum dos Pokémon oponentes forem do gênero oposto do usuário, ele se encanta, o que diminui duramente o seu Ataque Especial."
   },
   "stealthRock": {
-    "name": "Stealth Rock"
+    "name": "Stealth Rock",
+    "effect": "O usuário arma uma armadilha de pedras flutuantes, causando dano aos Pokémon adversários que entrarem na batalha igual a um oitavo de seus PS máximos. Esse dano varia dependendo da compatibilidade de tipo do Pokémon com o tipo Pedra."
   },
   "grassKnot": {
-    "name": "Grass Knot"
+    "name": "Grass Knot",
+    "effect": "O usuário enreda o alvo com grama e o faz tropeçar. Quanto mais pesado o alvo, maior o poder do movimento (variando entre 20 e 120)."
   },
   "chatter": {
-    "name": "Chatter"
+    "name": "Chatter",
+    "effect": "O usuário ataca o alvo com ondas sonoras de tagarelice ensurdecedora. Isso também confunde o alvo."
   },
   "judgment": {
-    "name": "Judgment"
+    "name": "Judgment",
+    "effect": "O usuário libera incontáveis disparos de luz no alvo. O tipo deste movimento muda dependendo do tipo de Placa ou Disco de Memória que o usuário está segurando, se ele tiver a Habilidade Multitype ou RKS System."
   },
   "bugBite": {
-    "name": "Bug Bite"
+    "name": "Bug Bite",
+    "effect": "O usuário ataca mordendo o alvo. Se o alvo estiver segurando uma Fruta, o usuário a come e ganha seu efeito."
   },
   "chargeBeam": {
-    "name": "Charge Beam"
+    "name": "Charge Beam",
+    "effect": "O usuário ataca o alvo com uma carga elétrica. A eletricidade residual tem 70% de chance de aumentar o atributo de Ataque Especial do usuário."
   },
   "woodHammer": {
-    "name": "Wood Hammer"
+    "name": "Wood Hammer",
+    "effect": "O usuário arremessa seu corpo robusto contra o alvo para atacar. O usuário recebe um terço do dano causado por este movimento."
   },
   "aquaJet": {
-    "name": "Aqua Jet"
+    "name": "Aqua Jet",
+    "effect": "O usuário se lança sobre o alvo para causar dano, movendo-se a uma velocidade cegante. Este movimento sempre ocorre primeiro."
   },
   "attackOrder": {
-    "name": "Attack Order"
+    "name": "Attack Order",
+    "effect": "O usuário convoca seus subordinados para golpear o alvo. A taxa de golpe crítico deste movimento é aumentada em 1 estágio."
   },
   "defendOrder": {
-    "name": "Defend Order"
+    "name": "Defend Order",
+    "effect": "O usuário convoca seus subordinados para proteger seu corpo, aumentando seus atributos de Defesa e Defesa Especial."
   },
   "healOrder": {
-    "name": "Heal Order"
+    "name": "Heal Order",
+    "effect": "O usuário convoca seus subordinados para curá-lo, restaurando metade de seus PS máximos."
   },
   "headSmash": {
-    "name": "Head Smash"
+    "name": "Head Smash",
+    "effect": "O usuário ataca o alvo com uma perigosa cabeçada de poder total. O usuário recebe metade do dano causado por este movimento."
   },
   "doubleHit": {
-    "name": "Double Hit"
+    "name": "Double Hit",
+    "effect": "O usuário golpeia o alvo com uma cauda ou algo do tipo. O alvo é atingido duas vezes seguidas."
   },
   "roarOfTime": {
     "name": "Roar of Time",
     "effect": "O usuário bombardeia o alvo com tamanho poder que distorce até mesmo o tempo; porém, não se moverá no próximo turno."
   },
   "spacialRend": {
-    "name": "Spacial Rend"
+    "name": "Spacial Rend",
+    "effect": "O usuário rasga o alvo junto com o espaço ao seu redor. A taxa de golpe crítico deste movimento é aumentada em 1 estágio."
   },
   "lunarDance": {
     "name": "Lunar Dance",
     "effect": "O usuário desmaia. Em troca, o Pokémon que assumir seu lugar terá seus PS e PP restaurados e suas condições de status curadas."
   },
   "crushGrip": {
-    "name": "Crush Grip"
+    "name": "Crush Grip",
+    "effect": "O alvo é esmagado com grande força. Quanto mais PS o alvo tiver, maior o poder do movimento (variando entre 1 e 120)."
   },
   "magmaStorm": {
-    "name": "Magma Storm"
+    "name": "Magma Storm",
+    "effect": "O usuário prende o alvo dentro de um turbilhão de fogo. Por 4 a 5 turnos, o alvo recebe dano igual a um oitavo de seus PS máximos ao final de cada turno."
   },
   "darkVoid": {
-    "name": "Dark Void"
+    "name": "Dark Void",
+    "effect": "Os Pokémon adversários são arrastados para um mundo de escuridão total que os faz dormir."
   },
   "seedFlare": {
-    "name": "Seed Flare"
+    "name": "Seed Flare",
+    "effect": "O usuário emite uma onda de choque de seu corpo para atacar o alvo. Este movimento tem 40% de chance de reduzir duramente o atributo de Defesa Especial do alvo."
   },
   "ominousWind": {
-    "name": "Ominous Wind"
+    "name": "Ominous Wind",
+    "effect": "O usuário ataca com uma rajada de vento horrível que arrepia a pele do alvo. Isso tem 10% de chance de aumentar de uma só vez os atributos de Ataque, Defesa, Ataque Especial, Defesa Especial e Velocidade do usuário."
   },
   "shadowForce": {
-    "name": "Shadow Force"
+    "name": "Shadow Force",
+    "effect": "O usuário desaparece no primeiro turno e ataca no turno seguinte. Este movimento pode atingir um alvo que esteja usando um movimento como Protect ou Detect e remove os efeitos desses movimentos."
   },
   "honeClaws": {
     "name": "Hone Claws",
     "effect": "O usuário afia suas garras para fortalecer seu Ataque e sua Precisão."
   },
   "wideGuard": {
-    "name": "Wide Guard"
+    "name": "Wide Guard",
+    "effect": "Durante o turno em que este movimento é usado, o usuário protege seu lado do campo de movimentos que atingem todos os aliados."
   },
   "guardSplit": {
-    "name": "Guard Split"
+    "name": "Guard Split",
+    "effect": "O usuário emprega seu poder psíquico para somar seus atributos de Defesa e Defesa Especial aos do alvo e depois divide o total pela metade para que compartilhem."
   },
   "powerSplit": {
-    "name": "Power Split"
+    "name": "Power Split",
+    "effect": "O usuário emprega seu poder psíquico para somar seus atributos de Ataque e Ataque Especial aos do alvo e depois divide o total pela metade para que compartilhem."
   },
   "wonderRoom": {
-    "name": "Wonder Room"
+    "name": "Wonder Room",
+    "effect": "O usuário cria uma área bizarra na qual os atributos de Defesa e Defesa Especial dos Pokémon são trocados por 5 turnos."
   },
   "psyshock": {
-    "name": "Psyshock"
+    "name": "Psyshock",
+    "effect": "O usuário materializa uma estranha onda psíquica para atacar o alvo. Este movimento causa dano físico."
   },
   "venoshock": {
-    "name": "Venoshock"
+    "name": "Venoshock",
+    "effect": "O usuário encharca o alvo com um líquido venenoso especial. O poder deste movimento é duplicado se o alvo estiver envenenado ou gravemente envenenado."
   },
   "autotomize": {
-    "name": "Autotomize"
+    "name": "Autotomize",
+    "effect": "O usuário se desfaz de parte de seu corpo para ficar mais leve. Isso aumenta bruscamente o atributo de Velocidade do usuário."
   },
   "ragePowder": {
-    "name": "Rage Powder"
+    "name": "Rage Powder",
+    "effect": "O usuário espalha uma nuvem de pó irritante para chamar a atenção para si mesmo, fazendo com que todos os Pokémon adversários mirem apenas no usuário."
   },
   "telekinesis": {
-    "name": "Telekinesis"
+    "name": "Telekinesis",
+    "effect": "O usuário faz o alvo flutuar com seu poder psíquico por 3 turnos. O alvo fica imune a movimentos do tipo Terrestre enquanto flutua, mas os movimentos usados contra ele com certeza acertam (exceto movimentos de nocaute com um golpe)."
   },
   "magicRoom": {
-    "name": "Magic Room"
+    "name": "Magic Room",
+    "effect": "O usuário cria uma área bizarra na qual os itens segurados pelos Pokémon perdem seus efeitos por 5 turnos."
   },
   "smackDown": {
-    "name": "Smack Down"
+    "name": "Smack Down",
+    "effect": "O usuário arremessa uma pedra ou projétil semelhante para atacar o alvo. Este movimento pode atingir Pokémon adversários que estejam no ar, incluindo os que usam Fly, Bounce ou Sky Drop, derrubando-os no chão."
   },
   "stormThrow": {
-    "name": "Storm Throw"
+    "name": "Storm Throw",
+    "effect": "O usuário ataca desferindo um golpe feroz contra o alvo. Este movimento sempre resulta em um golpe crítico."
   },
   "flameBurst": {
-    "name": "Flame Burst"
+    "name": "Flame Burst",
+    "effect": "O usuário ataca o alvo com uma chama explosiva. Pokémon ao lado do alvo também recebem dano igual a um dezesseis avos de seus PS máximos."
   },
   "sludgeWave": {
-    "name": "Sludge Wave"
+    "name": "Sludge Wave",
+    "effect": "O usuário atinge tudo ao seu redor inundando a área com uma onda gigante de lodo. Este movimento tem 10% de chance de envenenar os alvos."
   },
   "quiverDance": {
     "name": "Quiver Dance",
     "effect": "O usuário executa uma dança leve, bela e mística. Isso aumenta os atributos de Ata. Esp., Def. Esp. e Velocidade do usuário."
   },
   "heavySlam": {
-    "name": "Heavy Slam"
+    "name": "Heavy Slam",
+    "effect": "O usuário se choca contra o alvo com seu corpo pesado. Quanto mais o usuário for mais pesado que o alvo, maior o poder do movimento (variando entre 40 e 120). Se o alvo tiver usado Minimize, o poder deste movimento é duplicado e ele sempre acertará."
   },
   "synchronoise": {
     "name": "Synchronoise",
     "effect": "Usando uma estranha onda de choque, o usuário inflige dano em qualquer Pokémon do mesmo tipo na área ao seu redor."
   },
   "electroBall": {
-    "name": "Electro Ball"
+    "name": "Electro Ball",
+    "effect": "O usuário arremessa um orbe elétrico no alvo. Quanto maior o atributo de Velocidade do usuário em comparação ao do alvo, maior o poder deste movimento (variando entre 40 e 150)."
   },
   "soak": {
-    "name": "Soak"
+    "name": "Soak",
+    "effect": "O usuário dispara uma torrente de água que muda o tipo do alvo para Água."
   },
   "flameCharge": {
-    "name": "Flame Charge"
+    "name": "Flame Charge",
+    "effect": "Envolvendo-se em chamas, o usuário ataca o alvo. Então, acumulando ímpeto, o usuário aumenta seu atributo de Velocidade."
   },
   "coil": {
-    "name": "Coil"
+    "name": "Coil",
+    "effect": "O usuário se enrola e se concentra. Isso aumenta seus atributos de Ataque e Defesa, bem como sua Precisão."
   },
   "lowSweep": {
     "name": "Low Sweep",
     "effect": "O usuário realiza um ataque rápido nas pernas do alvo, o que reduz o atributo de Velocidade do alvo."
   },
   "acidSpray": {
-    "name": "Acid Spray"
+    "name": "Acid Spray",
+    "effect": "O usuário ataca cuspindo um fluido que derrete o alvo. Isso também reduz duramente o atributo de Defesa Especial do alvo."
   },
   "foulPlay": {
-    "name": "Foul Play"
+    "name": "Foul Play",
+    "effect": "O usuário usa a força do alvo contra ele mesmo. O dano causado por este movimento é determinado usando o atributo de Ataque do alvo em vez do atributo de Ataque do usuário."
   },
   "simpleBeam": {
-    "name": "Simple Beam"
+    "name": "Simple Beam",
+    "effect": "O usuário emite uma misteriosa onda psíquica que muda a Habilidade do alvo para Simple."
   },
   "entrainment": {
     "name": "Entrainment",
@@ -1608,35 +1980,44 @@
     "effect": "O usuário auxilia o alvo e o faz usar seu movimento exatamente após o usuário."
   },
   "round": {
-    "name": "Round"
+    "name": "Round",
+    "effect": "O usuário ataca o alvo com uma canção. Se outros usarem este movimento, eles agirão imediatamente após o usuário inicial, e o poder de seus Rounds será duplicado."
   },
   "echoedVoice": {
-    "name": "Echoed Voice"
+    "name": "Echoed Voice",
+    "effect": "O usuário ataca o alvo com uma voz ecoante. O poder deste movimento é aumentado em 40 a cada turno em que este movimento é usado consecutivamente por qualquer Pokémon, até um máximo de 200."
   },
   "chipAway": {
-    "name": "Chip Away"
+    "name": "Chip Away",
+    "effect": "Procurando uma brecha, o usuário golpeia com consistência. Este movimento ignora as mudanças de atributos do alvo ao causar dano."
   },
   "clearSmog": {
-    "name": "Clear Smog"
+    "name": "Clear Smog",
+    "effect": "O usuário ataca o alvo arremessando um punhado de lama especial. Todas as mudanças de atributos são eliminadas."
   },
   "storedPower": {
-    "name": "Stored Power"
+    "name": "Stored Power",
+    "effect": "O usuário ataca o alvo com poder armazenado. O poder deste movimento é aumentado em 20 para cada estágio em que os atributos do usuário tenham sido aumentados."
   },
   "quickGuard": {
     "name": "Quick Guard",
     "effect": "O usuário protege a si mesmo e seus aliados de golpes de prioridade."
   },
   "allySwitch": {
-    "name": "Ally Switch"
+    "name": "Ally Switch",
+    "effect": "O usuário se teletransporta usando um poder estranho e troca de lugar com um de seus aliados. A cada uso consecutivo, a chance de sucesso deste movimento se torna um terço do que era antes."
   },
   "scald": {
-    "name": "Scald"
+    "name": "Scald",
+    "effect": "O usuário ataca disparando água fervente no alvo. Este movimento tem 30% de chance de causar queimadura no alvo e descongelará o usuário ou o alvo caso um deles esteja congelado."
   },
   "shellSmash": {
-    "name": "Shell Smash"
+    "name": "Shell Smash",
+    "effect": "O usuário quebra sua concha, o que reduz seus atributos de Defesa e Defesa Especial, mas aumenta bruscamente seus atributos de Ataque, Ataque Especial e Velocidade."
   },
   "healPulse": {
-    "name": "Heal Pulse"
+    "name": "Heal Pulse",
+    "effect": "O usuário emite um pulso curativo que restaura metade dos PS máximos do alvo."
   },
   "hex": {
     "name": "Hex",
@@ -1647,10 +2028,12 @@
     "effect": "O usuário leva o alvo para o céu, então o solta durante o próximo turno. O alvo não pode atacar enquanto estiver no céu."
   },
   "shiftGear": {
-    "name": "Shift Gear"
+    "name": "Shift Gear",
+    "effect": "O usuário gira suas engrenagens, aumentando seu atributo de Ataque e aumentando bruscamente seu atributo de Velocidade."
   },
   "circleThrow": {
-    "name": "Circle Throw"
+    "name": "Circle Throw",
+    "effect": "O usuário ataca por último. Em troca, o alvo é arremessado e um Pokémon diferente é arrastado para a batalha. Em batalhas selvagens, isso encerra a batalha contra um único Pokémon."
   },
   "incinerate": {
     "name": "Incinerate",
@@ -1661,155 +2044,200 @@
     "effect": "O usuário reprime o alvo e o faz se mover por último."
   },
   "acrobatics": {
-    "name": "Acrobatics"
+    "name": "Acrobatics",
+    "effect": "O usuário golpeia o alvo com agilidade. Quanto menos itens segurados, maior o dano causado (variando entre 55 e 110)."
   },
   "reflectType": {
-    "name": "Reflect Type"
+    "name": "Reflect Type",
+    "effect": "O usuário reflete o tipo do alvo para se tornar do mesmo tipo que o alvo."
   },
   "retaliate": {
-    "name": "Retaliate"
+    "name": "Retaliate",
+    "effect": "O usuário se vinga de um aliado que desmaiou. O poder deste movimento é duplicado se um aliado tiver desmaiado no turno anterior."
   },
   "finalGambit": {
-    "name": "Final Gambit"
+    "name": "Final Gambit",
+    "effect": "O usuário arrisca tudo para atacar o alvo. O usuário desmaia, mas causa dano igual aos seus PS restantes no momento em que este movimento foi usado."
   },
   "bestow": {
-    "name": "Bestow"
+    "name": "Bestow",
+    "effect": "O usuário passa um item segurado para o alvo."
   },
   "inferno": {
     "name": "Inferno",
     "effect": "O usuário ataca engolindo o alvo em intensas chamas. intense fire. Isso deixa o alvo com uma queimadura."
   },
   "waterPledge": {
-    "name": "Water Pledge"
+    "name": "Water Pledge",
+    "effect": "Uma coluna de água atinge o alvo. Quando usado junto com Fire Pledge ou Grass Pledge, os movimentos se combinam para 150 de poder base e invocam um arco-íris ou um vasto pântano, respectivamente, por 4 turnos."
   },
   "firePledge": {
-    "name": "Fire Pledge"
+    "name": "Fire Pledge",
+    "effect": "Uma coluna de fogo atinge o alvo. Quando usado junto com Water Pledge ou Grass Pledge, os movimentos se combinam para 150 de poder base e invocam um arco-íris ou um vasto mar de fogo, respectivamente, por 4 turnos."
   },
   "grassPledge": {
-    "name": "Grass Pledge"
+    "name": "Grass Pledge",
+    "effect": "Uma coluna de grama atinge o alvo. Quando usado junto com Water Pledge ou Fire Pledge, os movimentos se combinam para 150 de poder base e invocam um vasto pântano ou um mar de fogo, respectivamente, por 4 turnos."
   },
   "voltSwitch": {
     "name": "Volt Switch",
     "effect": "Depois de fazer o seu ataque, o usuário corre de volta para trocar de lugar com um Pokémon da própria equipe."
   },
   "struggleBug": {
-    "name": "Struggle Bug"
+    "name": "Struggle Bug",
+    "effect": "O usuário ataca debatendo-se contra os Pokémon adversários. Isso também reduz os atributos de Ataque Especial deles."
   },
   "bulldoze": {
     "name": "Bulldoze",
     "effect": "O usuário ataca tudo ao seu redor pisando forte no chão. Isso reduz os atributos de Velocidade dos atingidos."
   },
   "frostBreath": {
-    "name": "Frost Breath"
+    "name": "Frost Breath",
+    "effect": "O usuário ataca soprando seu bafo gelado no alvo. Este movimento sempre resulta em um golpe crítico."
   },
   "dragonTail": {
-    "name": "Dragon Tail"
+    "name": "Dragon Tail",
+    "effect": "O usuário ataca por último. Em troca, o alvo é lançado para longe e um Pokémon diferente é arrastado para a batalha. Em batalhas selvagens, isso encerra a batalha contra um único Pokémon."
   },
   "workUp": {
-    "name": "Work Up"
+    "name": "Work Up",
+    "effect": "O usuário se anima, e seus atributos de Ataque e Ataque Especial são aumentados."
   },
   "electroweb": {
-    "name": "Electroweb"
+    "name": "Electroweb",
+    "effect": "O usuário captura os Pokémon adversários em uma rede elétrica para causar dano. Isso também reduz os atributos de Velocidade deles."
   },
   "wildCharge": {
-    "name": "Wild Charge"
+    "name": "Wild Charge",
+    "effect": "O usuário se envolve em eletricidade e se choca contra o alvo. O usuário recebe um quarto do dano causado por este movimento."
   },
   "drillRun": {
-    "name": "Drill Run"
+    "name": "Drill Run",
+    "effect": "O usuário se choca contra o alvo girando o corpo como uma broca. A taxa de golpe crítico deste movimento é aumentada em 1 estágio."
   },
   "dualChop": {
     "name": "Dual Chop",
     "effect": "O usuário ataca o seu alvo o acertando com golpes brutais. O alvo é atingido duas vezes seguidas."
   },
   "heartStamp": {
-    "name": "Heart Stamp"
+    "name": "Heart Stamp",
+    "effect": "O usuário desfere um golpe cruel depois que seu ato fofo deixa o alvo menos atento. Este movimento tem 30% de chance de fazer o alvo hesitar."
   },
   "hornLeech": {
-    "name": "Horn Leech"
+    "name": "Horn Leech",
+    "effect": "O usuário drena a energia do alvo com seus chifres. Os PS do usuário são restaurados em metade do dano causado por este movimento."
   },
   "sacredSword": {
-    "name": "Sacred Sword"
+    "name": "Sacred Sword",
+    "effect": "O usuário ataca cortando com uma espada. Este movimento ignora as mudanças de atributos do alvo ao causar dano."
   },
   "razorShell": {
-    "name": "Razor Shell"
+    "name": "Razor Shell",
+    "effect": "O usuário corta o alvo com conchas afiadas para causar dano. Este movimento tem 50% de chance de reduzir o atributo de Defesa do alvo."
   },
   "heatCrash": {
-    "name": "Heat Crash"
+    "name": "Heat Crash",
+    "effect": "O usuário se choca contra o alvo com seu corpo coberto de chamas. Quanto mais o usuário for mais pesado que o alvo, maior o poder do movimento (variando entre 40 e 120). Se o alvo tiver usado Minimize, o poder deste movimento é duplicado e ele sempre acertará."
   },
   "leafTornado": {
-    "name": "Leaf Tornado"
+    "name": "Leaf Tornado",
+    "effect": "O usuário ataca seu alvo cercando-o com folhas afiadas. Este movimento tem 50% de chance de reduzir a Precisão do alvo."
   },
   "steamroller": {
-    "name": "Steamroller"
+    "name": "Steamroller",
+    "effect": "O usuário esmaga seu alvo rolando sobre ele com seu corpo enrolado. Este movimento tem 30% de chance de fazer o alvo hesitar."
   },
   "cottonGuard": {
-    "name": "Cotton Guard"
+    "name": "Cotton Guard",
+    "effect": "O usuário se protege envolvendo o corpo em algodão macio, aumentando drasticamente seu atributo de Defesa."
   },
   "nightDaze": {
-    "name": "Night Daze"
+    "name": "Night Daze",
+    "effect": "O usuário libera uma onda de choque negra como breu no alvo para causar dano. Este movimento tem 40% de chance de reduzir a Precisão do alvo."
   },
   "psystrike": {
-    "name": "Psystrike"
+    "name": "Psystrike",
+    "effect": "O usuário materializa uma estranha onda psíquica para atacar o alvo. Este movimento causa dano físico."
   },
   "tailSlap": {
-    "name": "Tail Slap"
+    "name": "Tail Slap",
+    "effect": "O usuário ataca golpeando o alvo com sua cauda rígida. Este movimento atinge de duas a cinco vezes seguidas."
   },
   "hurricane": {
-    "name": "Hurricane"
+    "name": "Hurricane",
+    "effect": "O usuário ataca envolvendo seu oponente em um vento feroz. Este movimento tem 30% de chance de confundir o alvo e nunca erra na chuva. Este movimento também pode atingir um alvo que esteja no ar por Fly, Bounce ou Sky Drop."
   },
   "headCharge": {
-    "name": "Head Charge"
+    "name": "Head Charge",
+    "effect": "O usuário investe com a cabeça contra o alvo, usando seu poderoso pelo de guarda. O usuário recebe um quarto do dano causado por este movimento."
   },
   "gearGrind": {
-    "name": "Gear Grind"
+    "name": "Gear Grind",
+    "effect": "O usuário ataca arremessando engrenagens de aço no alvo duas vezes seguidas."
   },
   "searingShot": {
-    "name": "Searing Shot"
+    "name": "Searing Shot",
+    "effect": "O usuário incendeia tudo ao seu redor em um inferno de chamas escarlates. Este movimento tem 30% de chance de causar queimadura nos alvos."
   },
   "technoBlast": {
-    "name": "Techno Blast"
+    "name": "Techno Blast",
+    "effect": "O usuário ataca disparando um feixe de luz no alvo. Quando usado por Genesect, o tipo deste movimento muda dependendo do Drive segurado."
   },
   "relicSong": {
-    "name": "Relic Song"
+    "name": "Relic Song",
+    "effect": "O usuário canta uma canção antiga e ataca tocando o coração dos Pokémon adversários que a ouvem. Este movimento tem 10% de chance de fazer o alvo dormir. Se usado por Meloetta, fará com que ele alterne entre suas Formas Aria e Pirouette."
   },
   "secretSword": {
-    "name": "Secret Sword"
+    "name": "Secret Sword",
+    "effect": "O usuário ataca cortando os alvos com uma longa espada. O estranho poder contido na espada causa dano físico ao alvo. Se um Keldeo souber este movimento, ele se transformará em sua forma Resolute."
   },
   "glaciate": {
-    "name": "Glaciate"
+    "name": "Glaciate",
+    "effect": "O usuário ataca soprando ar gélido nos Pokémon adversários. Isso também reduz os atributos de Velocidade deles."
   },
   "boltStrike": {
-    "name": "Bolt Strike"
+    "name": "Bolt Strike",
+    "effect": "O usuário se cerca de uma grande quantidade de eletricidade e investe contra o alvo. Este movimento tem 20% de chance de paralisar o alvo."
   },
   "blueFlare": {
-    "name": "Blue Flare"
+    "name": "Blue Flare",
+    "effect": "O usuário ataca envolvendo o alvo em uma chama azul intensa, porém bela. Este movimento tem 20% de chance de causar queimadura no alvo."
   },
   "fieryDance": {
-    "name": "Fiery Dance"
+    "name": "Fiery Dance",
+    "effect": "Envolto em chamas, o usuário dança e ataca o alvo. Este movimento tem 50% de chance de aumentar o atributo de Ataque Especial do usuário."
   },
   "freezeShock": {
-    "name": "Freeze Shock"
+    "name": "Freeze Shock",
+    "effect": "No turno seguinte ao uso deste movimento, o usuário atinge o alvo com gelo eletricamente carregado para causar dano. Este movimento tem 30% de chance de paralisar o alvo."
   },
   "iceBurn": {
-    "name": "Ice Burn"
+    "name": "Ice Burn",
+    "effect": "No turno seguinte ao uso deste movimento, o usuário cerca o alvo com um vento ultragelado e congelante para causar dano. Este movimento tem 30% de chance de causar queimadura no alvo."
   },
   "snarl": {
-    "name": "Snarl"
+    "name": "Snarl",
+    "effect": "O usuário rosna incessantemente para os alvos, reduzindo os atributos de Ataque Especial dos Pokémon adversários."
   },
   "icicleCrash": {
-    "name": "Icicle Crash"
+    "name": "Icicle Crash",
+    "effect": "O usuário ataca despencando grandes estalactites sobre o alvo. Este movimento tem 30% de chance de fazer o alvo hesitar."
   },
   "vCreate": {
-    "name": "V-create"
+    "name": "V-create",
+    "effect": "O usuário emite uma chama quente de sua testa e se lança contra o alvo para causar dano. Isso também reduz os atributos de Defesa, Defesa Especial e Velocidade do usuário."
   },
   "fusionFlare": {
-    "name": "Fusion Flare"
+    "name": "Fusion Flare",
+    "effect": "O usuário faz descer uma chama gigante. O poder deste movimento é duplicado se usado após Fusion Bolt. O usuário é descongelado caso esteja congelado."
   },
   "fusionBolt": {
-    "name": "Fusion Bolt"
+    "name": "Fusion Bolt",
+    "effect": "O usuário faz descer um raio gigante. O poder deste movimento é duplicado se usado após Fusion Flare."
   },
   "flyingPress": {
-    "name": "Flying Press"
+    "name": "Flying Press",
+    "effect": "O usuário mergulha do céu sobre o alvo. Este movimento é dos tipos Lutador e Voador simultaneamente. Se o alvo tiver usado Minimize, o poder deste movimento é duplicado e ele sempre acertará."
   },
   "matBlock": {
     "name": "Mat Block",
@@ -1820,87 +2248,108 @@
     "effect": "O usuário expurga um arroto danificante no alvo. O usuário deve comer uma Fruta para usar esse movimento."
   },
   "rototiller": {
-    "name": "Rototiller"
+    "name": "Rototiller",
+    "effect": "Arando o solo, o usuário facilita o crescimento das plantas. Isso aumenta os atributos de Ataque e Ataque Especial de todos os Pokémon do tipo Grama que estejam no chão na batalha."
   },
   "stickyWeb": {
-    "name": "Sticky Web"
+    "name": "Sticky Web",
+    "effect": "O usuário tece uma teia pegajosa ao redor da equipe adversária. Pokémon que entrarem na batalha terão seus atributos de Velocidade reduzidos. Pokémon como os tipos Voadores ou os que têm a Habilidade Levitate não são afetados."
   },
   "fellStinger": {
-    "name": "Fell Stinger"
+    "name": "Fell Stinger",
+    "effect": "Quando o usuário nocauteia um alvo com este movimento, o atributo de Ataque do usuário é aumentado drasticamente."
   },
   "phantomForce": {
-    "name": "Phantom Force"
+    "name": "Phantom Force",
+    "effect": "O usuário ataca desaparecendo nas sombras por um curto período e então ressurgindo para golpear o alvo no turno seguinte. Este movimento pode atingir um alvo que esteja usando um movimento como Protect ou Detect e remove os efeitos desses movimentos."
   },
   "trickOrTreat": {
-    "name": "Trick-or-Treat"
+    "name": "Trick-or-Treat",
+    "effect": "O usuário convida os alvos para brincar de gostosuras ou travessuras. Isso adiciona o tipo Fantasma ao tipo do alvo."
   },
   "nobleRoar": {
-    "name": "Noble Roar"
+    "name": "Noble Roar",
+    "effect": "Soltando um rugido nobre, o usuário intimida o alvo e reduz os atributos de Ataque e Ataque Especial do alvo."
   },
   "ionDeluge": {
     "name": "Ion Deluge",
     "effect": "O usuário dispersa partículas eletricamente carregadas, o que muda movimentos do tipo Normal para o tipo Elétrico."
   },
   "parabolicCharge": {
-    "name": "Parabolic Charge"
+    "name": "Parabolic Charge",
+    "effect": "O usuário ataca liberando uma onda de eletricidade. Os PS do usuário são restaurados em metade do dano causado por este movimento."
   },
   "forestsCurse": {
-    "name": "Forest’s Curse"
+    "name": "Forest’s Curse",
+    "effect": "O usuário lança a maldição da floresta sobre os alvos. Isso adiciona o tipo Grama ao tipo do alvo."
   },
   "petalBlizzard": {
-    "name": "Petal Blizzard"
+    "name": "Petal Blizzard",
+    "effect": "O usuário levanta uma violenta tempestade de pétalas e causa dano a tudo ao seu redor."
   },
   "freezeDry": {
-    "name": "Freeze-Dry"
+    "name": "Freeze-Dry",
+    "effect": "O usuário ataca reduzindo rapidamente a temperatura do alvo. Este movimento também é supereficaz contra Pokémon do tipo Água."
   },
   "disarmingVoice": {
     "name": "Disarming Voice",
     "effect": "Liberando um grito encantador, o usuário inflige dano emocional nos Pokémon oponentes. Esse ataque nunca erra."
   },
   "partingShot": {
-    "name": "Parting Shot"
+    "name": "Parting Shot",
+    "effect": "Com uma ameaça de despedida, o usuário reduz os atributos de Ataque e Ataque Especial do alvo. O usuário então sai da batalha para ser substituído por outro Pokémon da equipe."
   },
   "topsyTurvy": {
     "name": "Topsy-Turvy",
     "effect": "Todas as mudanças de atributos afetando o alvo viram de cabeça para baixo e se tornam o oposto do que eram."
   },
   "drainingKiss": {
-    "name": "Draining Kiss"
+    "name": "Draining Kiss",
+    "effect": "O usuário rouba os PS do alvo com um beijo. Os PS do usuário são restaurados em três quartos do dano causado por este movimento."
   },
   "craftyShield": {
     "name": "Crafty Shield",
     "effect": "O usuário protege a si mesmo e seus aliados de condições negativas com um misterioso poder. Isso não previne golpes que inflijam dano."
   },
   "flowerShield": {
-    "name": "Flower Shield"
+    "name": "Flower Shield",
+    "effect": "O usuário aumenta os atributos de Defesa de todos os Pokémon do tipo Grama na batalha com um poder misterioso."
   },
   "grassyTerrain": {
-    "name": "Grassy Terrain"
+    "name": "Grassy Terrain",
+    "effect": "Transforma todo o campo em Terreno de Grama por 5 turnos. Pokémon que estejam no chão têm o poder de seus movimentos do tipo Grama aumentado em 30% e recuperam um dezesseis avos de seus PS máximos ao final de cada turno."
   },
   "mistyTerrain": {
     "name": "Misty Terrain",
     "effect": "Transforma todo o campo em Terreno Enevoado por 5 turnos. Os Pokémon que estiverem no solo têm o poder de seus ataques do tipo Dragão reduzido pela metade, ficam imunes a condições de status e não podem ficar confusos."
   },
   "electrify": {
-    "name": "Electrify"
+    "name": "Electrify",
+    "effect": "Se este movimento atingir o alvo antes de ele usar um movimento, seu movimento se torna do tipo Elétrico naquele turno."
   },
   "playRough": {
-    "name": "Play Rough"
+    "name": "Play Rough",
+    "effect": "O usuário ataca brincando rudemente com o alvo. Este movimento tem 10% de chance de reduzir o atributo de Ataque do alvo."
   },
   "fairyWind": {
-    "name": "Fairy Wind"
+    "name": "Fairy Wind",
+    "effect": "O usuário ataca levantando um vento feérico para golpear o alvo."
   },
   "moonblast": {
-    "name": "Moonblast"
+    "name": "Moonblast",
+    "effect": "Tomando emprestado o poder da lua, o usuário ataca o alvo. Este movimento tem 10% de chance de reduzir o atributo de Ataque Especial do alvo."
   },
   "boomburst": {
-    "name": "Boomburst"
+    "name": "Boomburst",
+    "effect": "O usuário ataca tudo ao seu redor com o poder destrutivo de um terrível som explosivo."
   },
   "fairyLock": {
-    "name": "Fairy Lock"
+    "name": "Fairy Lock",
+    "effect": "Bloqueando o campo de batalha, o usuário impede que todos os Pokémon fujam ou sejam trocados da batalha durante o próximo turno."
   },
   "kingsShield": {
-    "name": "King’s Shield"
+    "name": "King’s Shield",
+    "effect": "O usuário assume uma postura defensiva enquanto se protege de dano. Qualquer atacante que usar movimentos de contato contra o usuário durante este turno terá seus atributos de Ataque reduzidos. A cada uso consecutivo, a chance de sucesso deste movimento se torna um terço do que era antes."
   },
   "playNice": {
     "name": "Play Nice",
@@ -1911,25 +2360,32 @@
     "effect": "O usuário conta um segredo para o alvo e o alvo perde sua habilidade de se concentrar. Isso diminui o Ataque Especial do alvo."
   },
   "diamondStorm": {
-    "name": "Diamond Storm"
+    "name": "Diamond Storm",
+    "effect": "O usuário ataca envolvendo os alvos em uma tempestade de diamantes. Este movimento tem 50% de chance de aumentar bruscamente o atributo de Defesa do usuário."
   },
   "steamEruption": {
-    "name": "Steam Eruption"
+    "name": "Steam Eruption",
+    "effect": "O usuário ataca imergindo os alvos em vapor superaquecido. Este movimento tem 30% de chance de causar queimadura no alvo e descongelará o usuário ou o alvo caso um deles esteja congelado."
   },
   "hyperspaceHole": {
-    "name": "Hyperspace Hole"
+    "name": "Hyperspace Hole",
+    "effect": "O usuário ataca usando um buraco no hiperespaço para aparecer bem perto dos alvos sem aviso. Este ataque pode atingir um alvo que esteja usando um movimento como Protect ou Detect."
   },
   "waterShuriken": {
-    "name": "Water Shuriken"
+    "name": "Water Shuriken",
+    "effect": "O usuário atinge o alvo com estrelas de arremesso de duas a cinco vezes seguidas. Este movimento sempre ocorre primeiro. Quando usado por Ash-Greninja, o poder deste movimento é aumentado para 20 e ele sempre golpeará 3 vezes seguidas."
   },
   "mysticalFire": {
-    "name": "Mystical Fire"
+    "name": "Mystical Fire",
+    "effect": "O usuário ataca exalando um tipo especial de chama escaldante. Isso também reduz o atributo de Ataque Especial do alvo."
   },
   "spikyShield": {
-    "name": "Spiky Shield"
+    "name": "Spiky Shield",
+    "effect": "O usuário se protege dos movimentos que chegam durante o turno. Qualquer atacante que usar movimentos de contato contra o usuário durante este turno recebe dano igual a um oitavo de seus PS máximos. A cada uso consecutivo, a chance de sucesso deste movimento se torna um terço do que era antes."
   },
   "aromaticMist": {
-    "name": "Aromatic Mist"
+    "name": "Aromatic Mist",
+    "effect": "O usuário aumenta o atributo de Defesa Especial de um Pokémon aliado usando um aroma misterioso."
   },
   "eerieImpulse": {
     "name": "Eerie Impulse",
@@ -1940,20 +2396,24 @@
     "effect": "Os Pokémon adversários ficam encharcados com um líquido venenoso estranho. Isso reduz os atributos de Ataque, Ata. Esp. e Velocidade do alvo envenenado."
   },
   "powder": {
-    "name": "Powder"
+    "name": "Powder",
+    "effect": "O usuário cobre o alvo com um pó combustível. Se o alvo usar um movimento do tipo Fogo, o pó explode e o alvo recebe dano igual a um quarto de seus PS máximos."
   },
   "geomancy": {
-    "name": "Geomancy"
+    "name": "Geomancy",
+    "effect": "O usuário absorve energia no primeiro turno e então aumenta bruscamente seus atributos de Ataque Especial, Defesa Especial e Velocidade no turno seguinte."
   },
   "magneticFlux": {
-    "name": "Magnetic Flux"
+    "name": "Magnetic Flux",
+    "effect": "O usuário manipula campos magnéticos, o que aumenta os atributos de Defesa e Defesa Especial dos Pokémon aliados com a Habilidade Plus ou Minus."
   },
   "happyHour": {
     "name": "Happy Hour",
     "effect": "Usar Happy Hour dobra a quantidade de prêmio em dinheiro recebido após a batalha."
   },
   "electricTerrain": {
-    "name": "Electric Terrain"
+    "name": "Electric Terrain",
+    "effect": "O usuário transforma o chão em Terreno Elétrico por 5 turnos, potencializando os movimentos do tipo Elétrico. Pokémon que estejam no chão não podem mais adormecer."
   },
   "dazzlingGleam": {
     "name": "Dazzling Gleam",
@@ -1972,32 +2432,40 @@
     "effect": "O usuário encara o alvo com seus olhos adoráveis, o que diminui seu atributo de Ataque. Esse movimento tem prioridade."
   },
   "nuzzle": {
-    "name": "Nuzzle"
+    "name": "Nuzzle",
+    "effect": "O usuário ataca esfregando suas bochechas eletrificadas contra o alvo. Isso paralisa o alvo."
   },
   "holdBack": {
     "name": "Hold Back",
     "effect": "O usuário pega leve quando ataca e o alvo é deixado com pelo menos 1 PS."
   },
   "infestation": {
-    "name": "Infestation"
+    "name": "Infestation",
+    "effect": "O alvo é infestado e atacado. Por 4 a 5 turnos, o alvo recebe dano igual a um oitavo de seus PS máximos ao final de cada turno. O alvo não pode fugir nem ser trocado da batalha durante esse tempo."
   },
   "powerUpPunch": {
-    "name": "Power-Up Punch"
+    "name": "Power-Up Punch",
+    "effect": "O usuário ataca os alvos com um soco que torna seu próprio punho mais forte. Isso aumenta o atributo de Ataque do usuário."
   },
   "oblivionWing": {
-    "name": "Oblivion Wing"
+    "name": "Oblivion Wing",
+    "effect": "O usuário libera uma onda de destruição para absorver PS do alvo. Os PS do usuário são restaurados em três quartos do dano causado por este movimento."
   },
   "thousandArrows": {
-    "name": "Thousand Arrows"
+    "name": "Thousand Arrows",
+    "effect": "O usuário ataca gerando incontáveis flechas a partir de sua energia interna e fazendo-as chover sobre os alvos. Este movimento pode atingir Pokémon adversários que estejam no ar, incluindo os que usam Fly, Bounce ou Sky Drop, derrubando-os no chão."
   },
   "thousandWaves": {
-    "name": "Thousand Waves"
+    "name": "Thousand Waves",
+    "effect": "O usuário ataca liberando uma onda que rasteja pelo chão. Qualquer Pokémon atingido pela onda não pode fugir nem ser trocado da batalha."
   },
   "landsWrath": {
-    "name": "Land’s Wrath"
+    "name": "Land’s Wrath",
+    "effect": "O usuário reúne a energia da terra e concentra esse poder nos Pokémon adversários para causar dano."
   },
   "lightOfRuin": {
-    "name": "Light of Ruin"
+    "name": "Light of Ruin",
+    "effect": "Atraindo energia mística, o usuário dispara um poderoso feixe de luz. O usuário recebe metade do dano causado por este movimento."
   },
   "originPulse": {
     "name": "Origin Pulse",
@@ -2008,10 +2476,12 @@
     "effect": "O usuário ataca o Pokémon adversário manifestando o poder terrestre em espadas de pedra assustadoras."
   },
   "dragonAscent": {
-    "name": "Dragon Ascent"
+    "name": "Dragon Ascent",
+    "effect": "Após subir aos céus, o usuário ataca o alvo despencando do céu em alta velocidade. Isso também reduz os atributos de Defesa e Defesa Especial do usuário."
   },
   "hyperspaceFury": {
-    "name": "Hyperspace Fury"
+    "name": "Hyperspace Fury",
+    "effect": "Usando seus muitos braços, o usuário libera uma saraivada de ataques que ignoram os efeitos de movimentos como Protect e Detect. Isso também reduz o atributo de Defesa do usuário."
   },
   "breakneckBlitzPhysical": {
     "name": "Breakneck Blitz",
@@ -2162,38 +2632,48 @@
     "effect": "Utilizando seu Poder Z, Pikachu acumula o máximo de eletricidade que seu corpo suporta e pula no alvo com força total."
   },
   "shoreUp": {
-    "name": "Shore Up"
+    "name": "Shore Up",
+    "effect": "O usuário restaura metade de seus PS máximos levantando uma nuvem de areia dos arredores. Em uma tempestade de areia, o usuário restaura dois terços de seus PS máximos."
   },
   "firstImpression": {
-    "name": "First Impression"
+    "name": "First Impression",
+    "effect": "O usuário ataca com um poder tremendo, mas este movimento só tem sucesso se for usado logo que o usuário entra na batalha."
   },
   "banefulBunker": {
-    "name": "Baneful Bunker"
+    "name": "Baneful Bunker",
+    "effect": "O usuário se protege dos movimentos que chegam durante o turno. Qualquer atacante que usar movimentos de contato contra o usuário durante este turno fica envenenado. A cada uso consecutivo, a chance de sucesso deste movimento se torna um terço do que era antes."
   },
   "spiritShackle": {
-    "name": "Spirit Shackle"
+    "name": "Spirit Shackle",
+    "effect": "O usuário ataca enquanto simultaneamente prende a sombra do alvo ao chão para impedir que o alvo fuja ou seja trocado da batalha."
   },
   "darkestLariat": {
-    "name": "Darkest Lariat"
+    "name": "Darkest Lariat",
+    "effect": "O usuário gira ambos os braços e golpeia o alvo. Este movimento ignora as mudanças de atributos do alvo ao causar dano."
   },
   "sparklingAria": {
-    "name": "Sparkling Aria"
+    "name": "Sparkling Aria",
+    "effect": "O usuário irrompe em canto, emitindo muitas bolhas. Qualquer Pokémon que sofra de queimadura será curado pelo toque dessas bolhas."
   },
   "iceHammer": {
-    "name": "Ice Hammer"
+    "name": "Ice Hammer",
+    "effect": "O usuário desfere seu punho forte e pesado contra o alvo para causar dano. Isso também reduz o atributo de Velocidade do usuário."
   },
   "floralHealing": {
-    "name": "Floral Healing"
+    "name": "Floral Healing",
+    "effect": "O usuário restaura metade dos PS máximos do alvo. Quando o chão é Terreno de Grama, dois terços dos PS máximos do alvo são restaurados."
   },
   "highHorsepower": {
     "name": "High Horsepower",
     "effect": "O usuário ataca ferozmente o alvo usando todo o seu corpo."
   },
   "strengthSap": {
-    "name": "Strength Sap"
+    "name": "Strength Sap",
+    "effect": "O usuário restaura seus próprios PS na mesma quantidade do atributo de Ataque do alvo. Em seguida, reduz o atributo de Ataque do alvo."
   },
   "solarBlade": {
-    "name": "Solar Blade"
+    "name": "Solar Blade",
+    "effect": "O usuário reúne luz no primeiro turno e então preenche uma lâmina com a energia da luz e ataca no turno seguinte. Sob sol forte, o usuário pode atacar imediatamente. O poder deste movimento é reduzido pela metade em qualquer outra condição climática."
   },
   "leafage": {
     "name": "Leafage",
@@ -2204,26 +2684,32 @@
     "effect": "O usuário direciona o foco no alvo para que apenas ele seja atacado durante o turno."
   },
   "toxicThread": {
-    "name": "Toxic Thread"
+    "name": "Toxic Thread",
+    "effect": "O usuário dispara fios venenosos para envenenar o alvo e reduzir duramente o atributo de Velocidade do alvo."
   },
   "laserFocus": {
     "name": "Laser Focus",
     "effect": "O usuário concentra-se intensamente. O ataque no próximo turno sempre resulta em um golpe crítico."
   },
   "gearUp": {
-    "name": "Gear Up"
+    "name": "Gear Up",
+    "effect": "O usuário aciona suas engrenagens para aumentar os atributos de Ataque e Ataque Especial dos Pokémon aliados com a Habilidade Plus ou Minus."
   },
   "throatChop": {
-    "name": "Throat Chop"
+    "name": "Throat Chop",
+    "effect": "O usuário ataca a garganta do alvo, e o sofrimento resultante impede o alvo de usar movimentos baseados em som por 2 turnos."
   },
   "pollenPuff": {
-    "name": "Pollen Puff"
+    "name": "Pollen Puff",
+    "effect": "O usuário ataca o inimigo com um sopro de pólen que explode. Quando usado em um aliado, este movimento restaura metade de seus PS máximos em vez de causar dano."
   },
   "anchorShot": {
-    "name": "Anchor Shot"
+    "name": "Anchor Shot",
+    "effect": "O usuário enreda o alvo com sua corrente de âncora enquanto ataca. O alvo fica impossibilitado de fugir ou ser trocado da batalha."
   },
   "psychicTerrain": {
-    "name": "Psychic Terrain"
+    "name": "Psychic Terrain",
+    "effect": "Isso protege os Pokémon que estejam no chão de movimentos de prioridade e potencializa os movimentos do tipo Psíquico por 5 turnos."
   },
   "lunge": {
     "name": "Lunge",
@@ -2234,10 +2720,12 @@
     "effect": "O usuário atinge o alvo com um chicote em chamas. Também diminui a Defesa do alvo."
   },
   "powerTrip": {
-    "name": "Power Trip"
+    "name": "Power Trip",
+    "effect": "O usuário ostenta sua força e ataca o alvo. O poder deste movimento é aumentado em 20 para cada estágio em que os atributos do usuário tenham sido aumentados."
   },
   "burnUp": {
-    "name": "Burn Up"
+    "name": "Burn Up",
+    "effect": "Para causar dano massivo, o usuário se queima por completo e perde o tipo Fogo. O usuário é descongelado caso esteja congelado. Este movimento falha a menos que seja usado por um tipo Fogo."
   },
   "speedSwap": {
     "name": "Speed Swap",
@@ -2252,33 +2740,40 @@
     "effect": "O usuário cura a condição de status do alvo. Se o movimento for bem-sucedido, ele também restaura os PS do próprio usuário."
   },
   "revelationDance": {
-    "name": "Revelation Dance"
+    "name": "Revelation Dance",
+    "effect": "O usuário ataca o alvo dançando com toda a sua força. Este movimento se torna do mesmo tipo que o tipo primário do usuário."
   },
   "coreEnforcer": {
-    "name": "Core Enforcer"
+    "name": "Core Enforcer",
+    "effect": "O usuário ataca disparando um poderoso feixe que chamusca o campo de batalha. Se os Pokémon danificados por este movimento já tiverem usado seus movimentos naquele turno, este movimento elimina os efeitos das Habilidades desses Pokémon."
   },
   "tropKick": {
     "name": "Trop Kick",
     "effect": "O usuário desfere um chute intenso de origens tropicais no alvo. Também diminui o Ataque do alvo."
   },
   "instruct": {
-    "name": "Instruct"
+    "name": "Instruct",
+    "effect": "O usuário instrui o alvo a reutilizar o último movimento usado pelo alvo."
   },
   "beakBlast": {
-    "name": "Beak Blast"
+    "name": "Beak Blast",
+    "effect": "O usuário primeiro aquece seu bico e então espera antes de atacar o alvo. Fazer contato direto com o usuário enquanto ele está aquecendo o bico resulta em queimadura."
   },
   "clangingScales": {
-    "name": "Clanging Scales"
+    "name": "Clanging Scales",
+    "effect": "O usuário esfrega as escamas de todo o seu corpo e faz um enorme barulho para atacar os Pokémon adversários. O atributo de Defesa do usuário é reduzido após o ataque."
   },
   "dragonHammer": {
-    "name": "Dragon Hammer"
+    "name": "Dragon Hammer",
+    "effect": "O usuário usa seu corpo como um martelo para golpear o alvo e causar dano."
   },
   "brutalSwing": {
     "name": "Brutal Swing",
     "effect": "O usuário balança o corpo violentamente para infligir dano a tudo em seu redor."
   },
   "auroraVeil": {
-    "name": "Aurora Veil"
+    "name": "Aurora Veil",
+    "effect": "Este movimento reduz pela metade o dano recebido de movimentos físicos e especiais por 5 turnos. Em Batalhas Duplas, esse dano é reduzido em um terço. Isso só pode ser usado sob granizo ou quando estiver nevando."
   },
   "sinisterArrowRaid": {
     "name": "Sinister Arrow Raid",
@@ -2321,23 +2816,28 @@
     "effect": "O usuário arma uma cilada explosiva. Se o usuário for atingido fisicamente, a cilada irá explodir e causar de dano ao Pokémon oponente."
   },
   "fleurCannon": {
-    "name": "Fleur Cannon"
+    "name": "Fleur Cannon",
+    "effect": "O usuário ataca liberando um forte feixe. O recuo deste movimento reduz duramente o atributo de Ataque Especial do usuário."
   },
   "psychicFangs": {
-    "name": "Psychic Fangs"
+    "name": "Psychic Fangs",
+    "effect": "O usuário ataca mordendo os alvos usando poder psíquico. Este movimento também pode quebrar barreiras como Light Screen, Reflect e Aurora Veil."
   },
   "stompingTantrum": {
-    "name": "Stomping Tantrum"
+    "name": "Stomping Tantrum",
+    "effect": "Movido pela frustração, o usuário ataca o alvo. O poder deste movimento é duplicado se o usuário não pôde agir ou se seu movimento errou ou falhou no turno anterior."
   },
   "shadowBone": {
-    "name": "Shadow Bone"
+    "name": "Shadow Bone",
+    "effect": "O usuário ataca golpeando os alvos com um osso no qual reside um espírito. Este movimento tem 20% de chance de reduzir o atributo de Defesa do alvo."
   },
   "accelerock": {
     "name": "Accelerock",
     "effect": "O usuário colide com o alvo em alta velocidade. Este movimento sempre ocorre primeiro."
   },
   "liquidation": {
-    "name": "Liquidation"
+    "name": "Liquidation",
+    "effect": "O usuário se choca contra o alvo usando uma rajada de água de força total. Este movimento tem 20% de chance de reduzir o atributo de Defesa do alvo."
   },
   "prismaticLaser": {
     "name": "Prismatic Laser",
@@ -2348,44 +2848,56 @@
     "effect": "O usuário se esconde na sombra do alvo, rouba seus aumentos de atributos e então, ataca-o."
   },
   "sunsteelStrike": {
-    "name": "Sunsteel Strike"
+    "name": "Sunsteel Strike",
+    "effect": "O usuário se choca contra o alvo com a força de um meteoro. Este movimento pode ignorar a Habilidade do alvo (com certas exceções)."
   },
   "moongeistBeam": {
-    "name": "Moongeist Beam"
+    "name": "Moongeist Beam",
+    "effect": "O usuário emite um raio sinistro para atacar o alvo. Este movimento pode ignorar a Habilidade do alvo (com certas exceções)."
   },
   "tearfulLook": {
-    "name": "Tearful Look"
+    "name": "Tearful Look",
+    "effect": "O usuário fica com os olhos marejados para fazer o alvo perder seu espírito combativo. Isso reduz os atributos de Ataque e Ataque Especial do alvo."
   },
   "zingZap": {
-    "name": "Zing Zap"
+    "name": "Zing Zap",
+    "effect": "O usuário se choca contra o alvo, desferindo um poderoso choque elétrico. Este movimento tem 30% de chance de fazer o alvo hesitar."
   },
   "naturesMadness": {
-    "name": "Nature’s Madness"
+    "name": "Nature’s Madness",
+    "effect": "O usuário atinge o alvo com toda a fúria da natureza. Isso causa ao alvo dano igual à metade de seus PS restantes."
   },
   "multiAttack": {
-    "name": "Multi-Attack"
+    "name": "Multi-Attack",
+    "effect": "Envolvendo-se em uma energia poderosa, o usuário se choca contra o alvo para causar dano. O tipo deste movimento muda dependendo do tipo de Disco de Memória ou Placa que o usuário está segurando, se ele tiver a Habilidade RKS System ou Multitype."
   },
   "tenMillionVoltThunderbolt": {
-    "name": "10,000,000 Volt Thunderbolt"
+    "name": "10,000,000 Volt Thunderbolt",
+    "effect": "O usuário, Pikachu usando um boné, potencializa uma descarga de eletricidade usando seu Poder-Z e a libera. A taxa de golpe crítico deste movimento é aumentada em 2 estágios."
   },
   "mindBlown": {
-    "name": "Mind Blown"
+    "name": "Mind Blown",
+    "effect": "O usuário ataca tudo ao seu redor fazendo sua própria cabeça explodir. Após atacar, o usuário recebe dano igual à metade de seus PS máximos."
   },
   "plasmaFists": {
     "name": "Plasma Fists",
     "effect": "O usuário ataca com punhos carregados eletricamente. Este movimento transforma movimentos do tipo Normal em movimentos do tipo Elétrico."
   },
   "photonGeyser": {
-    "name": "Photon Geyser"
+    "name": "Photon Geyser",
+    "effect": "O usuário ataca o alvo com um pilar de luz. Este movimento causa dano usando o atributo de Ataque ou Ataque Especial — o que for maior para o usuário. Este movimento pode ignorar o efeito da Habilidade do alvo (com certas exceções)."
   },
   "lightThatBurnsTheSky": {
-    "name": "Light That Burns the Sky"
+    "name": "Light That Burns the Sky",
+    "effect": "Este ataque causa dano de Ataque ou Ataque Especial — o atributo que for maior para o usuário, Necrozma. Este movimento pode ignorar o efeito da Habilidade do alvo (com certas exceções)."
   },
   "searingSunrazeSmash": {
-    "name": "Searing Sunraze Smash"
+    "name": "Searing Sunraze Smash",
+    "effect": "Após obter o Poder-Z, o usuário, Solgaleo, ataca o alvo com força total. Este movimento pode ignorar o efeito da Habilidade do alvo (com certas exceções)."
   },
   "menacingMoonrazeMaelstrom": {
-    "name": "Menacing Moonraze Maelstrom"
+    "name": "Menacing Moonraze Maelstrom",
+    "effect": "Após obter o Poder-Z, o usuário, Lunala, ataca o alvo com força total. Este movimento pode ignorar o efeito da Habilidade do alvo (com certas exceções)."
   },
   "letsSnuggleForever": {
     "name": "Let’s Snuggle Forever",
@@ -2404,31 +2916,40 @@
     "effect": "O usuário ataca o alvo com rajadas de eletricidade em alta velocidade. Este movimento sempre ocorre primeiro e resulta em um golpe crítico."
   },
   "splishySplash": {
-    "name": "Splishy Splash"
+    "name": "Splishy Splash",
+    "effect": "O usuário carrega uma onda enorme com eletricidade e atinge os Pokémon adversários com a onda. Este movimento tem 20% de chance de paralisar os alvos."
   },
   "floatyFall": {
-    "name": "Floaty Fall"
+    "name": "Floaty Fall",
+    "effect": "O usuário flutua no ar e então mergulha em um ângulo acentuado para atacar o alvo. Este movimento tem 30% de chance de fazer o alvo hesitar."
   },
   "pikaPapow": {
-    "name": "Pika Papow"
+    "name": "Pika Papow",
+    "effect": "Quanto mais Pikachu ama seu Treinador, maior o poder do movimento (variando entre 1 e 102). Este ataque nunca erra."
   },
   "bouncyBubble": {
-    "name": "Bouncy Bubble"
+    "name": "Bouncy Bubble",
+    "effect": "O usuário ataca disparando bolhas de água no alvo. Ele então absorve água e restaura seus PS em 100% do dano causado por este movimento."
   },
   "buzzyBuzz": {
-    "name": "Buzzy Buzz"
+    "name": "Buzzy Buzz",
+    "effect": "O usuário dispara uma descarga de eletricidade para atacar o alvo. Isso também paralisa o alvo."
   },
   "sizzlySlide": {
-    "name": "Sizzly Slide"
+    "name": "Sizzly Slide",
+    "effect": "O usuário se envolve em fogo e investe contra o alvo. Isso também causa queimadura no alvo."
   },
   "glitzyGlow": {
-    "name": "Glitzy Glow"
+    "name": "Glitzy Glow",
+    "effect": "O usuário bombardeia o alvo com força telecinética. Uma maravilhosa parede de luz é erguida para reduzir pela metade o dano recebido de movimentos especiais. Em Batalhas Duplas, esse dano é reduzido em um terço."
   },
   "baddyBad": {
-    "name": "Baddy Bad"
+    "name": "Baddy Bad",
+    "effect": "O usuário age como vilão e ataca o alvo. Uma maravilhosa parede de luz é erguida para reduzir pela metade o dano recebido de movimentos físicos. Em Batalhas Duplas, esse dano é reduzido em um terço."
   },
   "sappySeed": {
-    "name": "Sappy Seed"
+    "name": "Sappy Seed",
+    "effect": "O usuário faz crescer um talo gigantesco que espalha sementes para atacar o alvo. Ao final de cada turno, um oitavo dos PS máximos do alvo é absorvido pelo usuário ou por qualquer Pokémon que assuma seu lugar na batalha."
   },
   "freezyFrost": {
     "name": "Freezy Frost",
@@ -2439,132 +2960,164 @@
     "effect": "O usuário ataca o alvo envolvendo-o em um redemoinho de um aroma avassalador. Isso também cura as condições de status de todos os Pokémon do grupo e aliados."
   },
   "veeveeVolley": {
-    "name": "Veevee Volley"
+    "name": "Veevee Volley",
+    "effect": "Quanto mais Eevee ama seu Treinador, maior o poder do movimento (variando entre 1 e 102). Este ataque nunca erra."
   },
   "doubleIronBash": {
-    "name": "Double Iron Bash"
+    "name": "Double Iron Bash",
+    "effect": "O usuário gira, firmando-se com um giro, e então golpeia com seus braços duas vezes seguidas. Cada acerto tem 30% de chance de fazer o alvo hesitar."
   },
   "maxGuard": {
-    "name": "Max Guard"
+    "name": "Max Guard",
+    "effect": "Este movimento permite que o usuário se proteja de todos os ataques. A cada uso consecutivo, a chance de sucesso deste movimento se torna um terço do que era antes."
   },
   "dynamaxCannon": {
-    "name": "Dynamax Cannon"
+    "name": "Dynamax Cannon",
+    "effect": "O usuário condensa energia dentro de seu corpo e libera essa energia de seu núcleo para causar dano. Causa até o dobro do dano se o alvo estiver com nível excessivo."
   },
   "snipeShot": {
-    "name": "Snipe Shot"
+    "name": "Snipe Shot",
+    "effect": "O usuário ignora os efeitos dos movimentos e Habilidades dos Pokémon adversários que atraem movimentos. A taxa de golpe crítico deste movimento é aumentada em 1 estágio."
   },
   "jawLock": {
     "name": "Jaw Lock",
     "effect": "Este movimento impede o usuário e o alvo de trocarem de lugar até que um deles desmaie. O efeito desaparece se qualquer um dos Pokémon deixar o campo de batalha."
   },
   "stuffCheeks": {
-    "name": "Stuff Cheeks"
+    "name": "Stuff Cheeks",
+    "effect": "O usuário come sua Fruta segurada e então aumenta bruscamente seu atributo de Defesa."
   },
   "noRetreat": {
-    "name": "No Retreat"
+    "name": "No Retreat",
+    "effect": "O usuário arrisca tudo e aumenta seus atributos de Ataque, Defesa, Ataque Especial, Defesa Especial e Velocidade. Em troca, o usuário perde a capacidade de fugir ou ser trocado da batalha. Só pode ser usado uma vez cada vez que o usuário entra na batalha."
   },
   "tarShot": {
-    "name": "Tar Shot"
+    "name": "Tar Shot",
+    "effect": "O usuário despeja alcatrão pegajoso sobre o alvo, reduzindo o atributo de Velocidade do alvo. Movimentos do tipo Fogo usados no alvo têm sua eficácia duplicada."
   },
   "magicPowder": {
-    "name": "Magic Powder"
+    "name": "Magic Powder",
+    "effect": "O usuário espalha uma nuvem de pó mágico que muda o tipo do alvo para Psíquico."
   },
   "dragonDarts": {
-    "name": "Dragon Darts"
+    "name": "Dragon Darts",
+    "effect": "O usuário ataca duas vezes lançando flechas dracônicas. Se houver 2 Pokémon adversários, cada um deles é atacado uma vez."
   },
   "teatime": {
-    "name": "Teatime"
+    "name": "Teatime",
+    "effect": "O usuário faz um chá da tarde com todos os Pokémon presentes na batalha. Cada Pokémon come uma Fruta segurada."
   },
   "octolock": {
-    "name": "Octolock"
+    "name": "Octolock",
+    "effect": "O usuário prende o alvo e o impede de fugir ou ser trocado da batalha. Este movimento também reduz os atributos de Defesa e Defesa Especial do alvo a cada turno."
   },
   "boltBeak": {
-    "name": "Bolt Beak"
+    "name": "Bolt Beak",
+    "effect": "O usuário perfura o alvo com seu bico eletrificado. O poder deste movimento é duplicado se o usuário se mover antes do alvo."
   },
   "fishiousRend": {
-    "name": "Fishious Rend"
+    "name": "Fishious Rend",
+    "effect": "O usuário dilacera o alvo com suas guelras rígidas. O poder deste movimento é duplicado se o usuário se mover antes do alvo."
   },
   "courtChange": {
     "name": "Court Change",
     "effect": "Com seu poder misterioso, o usuário troca os efeitos de cada lado do campo de batalha."
   },
   "maxFlare": {
-    "name": "Max Flare"
+    "name": "Max Flare",
+    "effect": "Este é um ataque do tipo Fogo que os Pokémon Dynamax usam. O usuário intensifica o sol por 5 turnos."
   },
   "maxFlutterby": {
     "name": "Max Flutterby",
     "effect": "Este é um ataque do tipo Inseto que Pokémon Dynamax usam. Isso diminui o atributo de Atq. Esp. do alvo."
   },
   "maxLightning": {
-    "name": "Max Lightning"
+    "name": "Max Lightning",
+    "effect": "Este é um ataque do tipo Elétrico que os Pokémon Dynamax usam. O usuário transforma o chão em Terreno Elétrico por 5 turnos."
   },
   "maxStrike": {
     "name": "Max Strike",
     "effect": "Este é um ataque do tipo Normal usado pelos Pokémon Dynamax. Ele reduz o atributo de Velocidade do alvo."
   },
   "maxKnuckle": {
-    "name": "Max Knuckle"
+    "name": "Max Knuckle",
+    "effect": "Este é um ataque do tipo Lutador que os Pokémon Dynamax usam. Isso aumenta os atributos de Ataque dos Pokémon aliados."
   },
   "maxPhantasm": {
     "name": "Max Phantasm",
     "effect": "Este é um ataque do tipo Fantasma que Pokémon Dynamax usam. Isso diminui o atributo de Defesa do alvo."
   },
   "maxHailstorm": {
-    "name": "Max Hailstorm"
+    "name": "Max Hailstorm",
+    "effect": "Este é um ataque do tipo Gelo que os Pokémon Dynamax usam. O usuário invoca uma tempestade de granizo que dura 5 turnos."
   },
   "maxOoze": {
-    "name": "Max Ooze"
+    "name": "Max Ooze",
+    "effect": "Este é um ataque do tipo Venenoso que os Pokémon Dynamax usam. Isso aumenta os atributos de Ataque Especial dos Pokémon aliados."
   },
   "maxGeyser": {
-    "name": "Max Geyser"
+    "name": "Max Geyser",
+    "effect": "Este é um ataque do tipo Água que os Pokémon Dynamax usam. O usuário invoca uma chuva forte que cai por 5 turnos."
   },
   "maxAirstream": {
-    "name": "Max Airstream"
+    "name": "Max Airstream",
+    "effect": "Este é um ataque do tipo Voador que os Pokémon Dynamax usam. Isso aumenta os atributos de Velocidade dos Pokémon aliados."
   },
   "maxStarfall": {
-    "name": "Max Starfall"
+    "name": "Max Starfall",
+    "effect": "Este é um ataque do tipo Fada que os Pokémon Dynamax usam. O usuário transforma o chão em Terreno Enevoado por 5 turnos."
   },
   "maxWyrmwind": {
     "name": "Max Wyrmwind",
     "effect": "Este é um ataque do tipo Dragão que Pokémon Dynamax usam. Isso diminui o atributo de Ataque do alvo."
   },
   "maxMindstorm": {
-    "name": "Max Mindstorm"
+    "name": "Max Mindstorm",
+    "effect": "Este é um ataque do tipo Psíquico que os Pokémon Dynamax usam. O usuário transforma o chão em Terreno Psíquico por 5 turnos."
   },
   "maxRockfall": {
-    "name": "Max Rockfall"
+    "name": "Max Rockfall",
+    "effect": "Este é um ataque do tipo Pedra que os Pokémon Dynamax usam. O usuário invoca uma tempestade de areia que dura 5 turnos."
   },
   "maxQuake": {
-    "name": "Max Quake"
+    "name": "Max Quake",
+    "effect": "Este é um ataque do tipo Terrestre que os Pokémon Dynamax usam. Isso aumenta os atributos de Defesa Especial dos Pokémon aliados."
   },
   "maxDarkness": {
     "name": "Max Darkness",
     "effect": "Este é um ataque do tipo Sombrio que Pokémon Dynamax usam. Isso diminui o atributo de Def. Esp. do alvo."
   },
   "maxOvergrowth": {
-    "name": "Max Overgrowth"
+    "name": "Max Overgrowth",
+    "effect": "Este é um ataque do tipo Grama que os Pokémon Dynamax usam. O usuário transforma o chão em Terreno de Grama por 5 turnos."
   },
   "maxSteelspike": {
-    "name": "Max Steelspike"
+    "name": "Max Steelspike",
+    "effect": "Este é um ataque do tipo Aço que os Pokémon Dynamax usam. Isso aumenta os atributos de Defesa dos Pokémon aliados."
   },
   "clangorousSoul": {
-    "name": "Clangorous Soul"
+    "name": "Clangorous Soul",
+    "effect": "O usuário perde um terço de seus PS máximos para aumentar seus atributos de Ataque, Defesa, Ataque Especial, Defesa Especial e Velocidade. Este movimento falha se o usuário não tiver PS restantes suficientes."
   },
   "bodyPress": {
-    "name": "Body Press"
+    "name": "Body Press",
+    "effect": "O usuário ataca chocando seu corpo contra o alvo. O dano causado por este movimento é determinado usando o atributo de Defesa do usuário em vez de seu atributo de Ataque."
   },
   "decorate": {
-    "name": "Decorate"
+    "name": "Decorate",
+    "effect": "O usuário aumenta bruscamente os atributos de Ataque e Ataque Especial do alvo ao decorá-lo."
   },
   "drumBeating": {
     "name": "Drum Beating",
     "effect": "O usuário toca seu tambor, controlando as raízes do tambor para atacar o alvo. Isso também reduz o atributo de Velocidade do alvo."
   },
   "snapTrap": {
-    "name": "Snap Trap"
+    "name": "Snap Trap",
+    "effect": "O usuário prende o alvo em uma armadilha de mola. Por 4 a 5 turnos, o alvo recebe dano igual a um oitavo de seus PS máximos ao final de cada turno."
   },
   "pyroBall": {
-    "name": "Pyro Ball"
+    "name": "Pyro Ball",
+    "effect": "O usuário ataca acendendo uma pequena pedra e lançando-a como uma bola de fogo no alvo. Este movimento tem 10% de chance de causar queimadura no alvo e descongela o usuário caso ele esteja congelado."
   },
   "behemothBlade": {
     "name": "Behemoth Blade",
@@ -2575,7 +3128,8 @@
     "effect": "O corpo do usuário se torna um escudo firme e atinge o alvo com força."
   },
   "auraWheel": {
-    "name": "Aura Wheel"
+    "name": "Aura Wheel",
+    "effect": "O usuário ataca e aumenta sua Velocidade com a energia armazenada em suas bochechas. Quando usado por Morpeko, o tipo deste movimento muda dependendo de sua forma."
   },
   "breakingSwipe": {
     "name": "Breaking Swipe",
@@ -2586,68 +3140,84 @@
     "effect": "O usuário ataca o alvo cutucando-o com um galho pontiagudo."
   },
   "overdrive": {
-    "name": "Overdrive"
+    "name": "Overdrive",
+    "effect": "O usuário ataca os Pokémon adversários com uma onda sonora eletrizante, causando um enorme eco e uma forte vibração."
   },
   "appleAcid": {
     "name": "Apple Acid",
     "effect": "O usuário ataca o alvo com um líquido ácido criado a partir de maçãs azedas. Isso também diminui o atributo de Def. Esp. do alvo."
   },
   "gravApple": {
-    "name": "Grav Apple"
+    "name": "Grav Apple",
+    "effect": "O usuário causa dano deixando uma maçã cair do alto. Isso também reduz o atributo de Defesa do alvo. O poder deste movimento é aumentado em 50% quando Gravity está ativo."
   },
   "spiritBreak": {
     "name": "Spirit Break",
     "effect": "O usuário ataca o alvo com tanta força que poderia quebrar o espírito do alvo. Isso também diminui o atributo de Atq. Esp. do alvo."
   },
   "strangeSteam": {
-    "name": "Strange Steam"
+    "name": "Strange Steam",
+    "effect": "O usuário ataca o alvo emitindo vapor. Este movimento tem 20% de chance de confundir o alvo."
   },
   "lifeDew": {
-    "name": "Life Dew"
+    "name": "Life Dew",
+    "effect": "O usuário espalha uma água misteriosa ao redor e restaura um quarto dos PS máximos do usuário e de seus Pokémon aliados."
   },
   "obstruct": {
-    "name": "Obstruct"
+    "name": "Obstruct",
+    "effect": "Este movimento permite que o usuário se proteja de todos os ataques. Qualquer atacante que usar movimentos de contato contra o usuário durante este turno terá seus atributos de Defesa reduzidos duramente. A cada uso consecutivo, a chance de sucesso deste movimento se torna um terço do que era antes."
   },
   "falseSurrender": {
     "name": "False Surrender",
     "effect": "O usuário finge abaixar a cabeça, mas então esfaqueia o alvo com seus cabelos desgrenhados. Este ataque nunca erra."
   },
   "meteorAssault": {
-    "name": "Meteor Assault"
+    "name": "Meteor Assault",
+    "effect": "O usuário ataca descontroladamente com uma arma comprida. No entanto, isso também faz o usuário cambalear, deixando-o impossibilitado de se mover no próximo turno."
   },
   "eternabeam": {
     "name": "Eternabeam",
     "effect": "Este é o ataque mais poderoso de Eternatus em sua forma original. O usuário não pode se mover na próxima rodada."
   },
   "steelBeam": {
-    "name": "Steel Beam"
+    "name": "Steel Beam",
+    "effect": "O usuário dispara um feixe de aço que coletou de todo o seu corpo. Após atacar, o usuário recebe dano igual à metade de seus PS máximos."
   },
   "expandingForce": {
-    "name": "Expanding Force"
+    "name": "Expanding Force",
+    "effect": "O usuário ataca o alvo com seu poder psíquico. Se o usuário estiver sob o efeito do Terreno Psíquico, o poder deste movimento é aumentado em 50% e seu alcance se estende a todos os oponentes."
   },
   "steelRoller": {
-    "name": "Steel Roller"
+    "name": "Steel Roller",
+    "effect": "O usuário ataca enquanto destrói o terreno. Este movimento falha se o chão não tiver se transformado em um terreno."
   },
   "scaleShot": {
-    "name": "Scale Shot"
+    "name": "Scale Shot",
+    "effect": "O usuário ataca disparando escamas de duas a cinco vezes seguidas. Este movimento aumenta o atributo de Velocidade do usuário, mas reduz seu atributo de Defesa."
   },
   "meteorBeam": {
-    "name": "Meteor Beam"
+    "name": "Meteor Beam",
+    "effect": "O usuário reúne energia do espaço e aumenta seu atributo de Ataque Especial no primeiro turno, então ataca no turno seguinte."
   },
   "shellSideArm": {
-    "name": "Shell Side Arm"
+    "name": "Shell Side Arm",
+    "effect": "Este movimento é físico ou especial — o que causar mais dano. Este movimento tem 20% de chance de envenenar o alvo."
   },
   "mistyExplosion": {
-    "name": "Misty Explosion"
+    "name": "Misty Explosion",
+    "effect": "O usuário ataca tudo ao seu redor e desmaia ao usar este movimento. Se o usuário estiver sob o efeito do Terreno Enevoado, o poder deste movimento é aumentado em 50%."
   },
   "grassyGlide": {
-    "name": "Grassy Glide"
+    "name": "Grassy Glide",
+    "effect": "Deslizando pelo chão, o usuário ataca o alvo. Se o usuário estiver sob o efeito do Terreno de Grama, este movimento sempre ocorre primeiro."
   },
   "risingVoltage": {
-    "name": "Rising Voltage"
+    "name": "Rising Voltage",
+    "effect": "O usuário ataca com eletricidade que sobe do chão. O poder deste movimento é duplicado se o alvo estiver sob o efeito do Terreno Elétrico."
   },
   "terrainPulse": {
-    "name": "Terrain Pulse"
+    "name": "Terrain Pulse",
+    "effect": "O usuário utiliza a energia do terreno para atacar. O tipo e o poder deste movimento mudam dependendo do terreno no momento em que o movimento é usado."
   },
   "skitterSmack": {
     "name": "Skitter Smack",
@@ -2658,13 +3228,16 @@
     "effect": "O usuário ataca com energia da inveja. Isso deixa todos os Pokémon adversários que tiveram seus atributos aumentados durante o turno com uma queimadura."
   },
   "lashOut": {
-    "name": "Lash Out"
+    "name": "Lash Out",
+    "effect": "O usuário se descontrola para descontar sua frustração no alvo. O poder deste movimento é duplicado se os atributos do usuário tiverem sido reduzidos durante este turno."
   },
   "poltergeist": {
-    "name": "Poltergeist"
+    "name": "Poltergeist",
+    "effect": "O usuário ataca controlando um dos itens do alvo. Este movimento falha se o alvo não estiver segurando nenhum item."
   },
   "corrosiveGas": {
-    "name": "Corrosive Gas"
+    "name": "Corrosive Gas",
+    "effect": "O usuário cerca tudo ao seu redor com um gás altamente ácido e desativa os itens segurados por outros Pokémon pelo resto da batalha."
   },
   "coaching": {
     "name": "Coaching",
@@ -2675,35 +3248,44 @@
     "effect": "Após fazer seu ataque, o usuário corre para trocar de lugar com um Pokémon do grupo à espera."
   },
   "tripleAxel": {
-    "name": "Triple Axel"
+    "name": "Triple Axel",
+    "effect": "Um ataque consecutivo de três chutes que aumenta o poder em 20 a cada acerto sucessivo. Quando um chute erra, o movimento termina."
   },
   "dualWingbeat": {
-    "name": "Dual Wingbeat"
+    "name": "Dual Wingbeat",
+    "effect": "O usuário golpeia o alvo com suas asas para causar dano. O alvo é atingido duas vezes seguidas."
   },
   "scorchingSands": {
-    "name": "Scorching Sands"
+    "name": "Scorching Sands",
+    "effect": "O usuário arremessa areia escaldante no alvo para atacar. Este movimento tem 30% de chance de causar queimadura no alvo e descongelará o usuário ou o alvo caso um deles esteja congelado."
   },
   "jungleHealing": {
     "name": "Jungle Healing",
     "effect": "O usuário se funde com a selva, restaurando ¼ dos PS máximos do usuário e do Pokémon aliado, além de curar condições de status."
   },
   "wickedBlow": {
-    "name": "Wicked Blow"
+    "name": "Wicked Blow",
+    "effect": "O usuário golpeia o alvo com um golpe feroz. Este movimento sempre resulta em um golpe crítico."
   },
   "surgingStrikes": {
-    "name": "Surging Strikes"
+    "name": "Surging Strikes",
+    "effect": "O usuário golpeia o alvo com um movimento fluido 3 vezes seguidas. Este movimento sempre resulta em um golpe crítico."
   },
   "thunderCage": {
-    "name": "Thunder Cage"
+    "name": "Thunder Cage",
+    "effect": "O usuário prende o alvo dentro de uma jaula de eletricidade crepitante. Por 4 a 5 turnos, o alvo recebe dano igual a um oitavo de seus PS máximos ao final de cada turno."
   },
   "dragonEnergy": {
-    "name": "Dragon Energy"
+    "name": "Dragon Energy",
+    "effect": "Convertendo sua força vital em poder, o usuário ataca os Pokémon adversários. Quanto menos PS o usuário tiver, menor o poder deste movimento (variando entre 1 e 150)."
   },
   "freezingGlare": {
-    "name": "Freezing Glare"
+    "name": "Freezing Glare",
+    "effect": "O usuário dispara seu poder psíquico de seus olhos para atacar. Este movimento tem 10% de chance de congelar o alvo."
   },
   "fieryWrath": {
-    "name": "Fiery Wrath"
+    "name": "Fiery Wrath",
+    "effect": "O usuário transforma sua fúria em uma aura de fogo para atacar. Este movimento tem 20% de chance de fazer os alvos hesitarem."
   },
   "thunderousKick": {
     "name": "Thunderous Kick",
@@ -2718,10 +3300,12 @@
     "effect": "O usuário ataca enviando uma quantidade assustadora de pequenos fantasmas nos Pokémon adversários."
   },
   "eerieSpell": {
-    "name": "Eerie Spell"
+    "name": "Eerie Spell",
+    "effect": "O usuário ataca com seu tremendo poder psíquico. Isso também drena 3 PP do último movimento usado pelo alvo."
   },
   "direClaw": {
-    "name": "Dire Claw"
+    "name": "Dire Claw",
+    "effect": "O usuário ataca o alvo com garras ruinosas. Este movimento tem 30% de chance de deixar o alvo envenenado, paralisado ou adormecido."
   },
   "psyshieldBash": {
     "name": "Psyshield Bash",
@@ -2732,26 +3316,32 @@
     "effect": "O usuário troca seus atributos de Ataque e Defesa."
   },
   "stoneAxe": {
-    "name": "Stone Axe"
+    "name": "Stone Axe",
+    "effect": "O usuário desfere seus machados de pedra contra o alvo. Lascas de pedra deixadas por este ataque flutuam ao redor do alvo, causando dano aos Pokémon adversários que entrarem na batalha igual a um oitavo de seus PS máximos. O dano das lascas de pedra varia dependendo da compatibilidade de tipo do Pokémon com o tipo Pedra."
   },
   "springtideStorm": {
-    "name": "Springtide Storm"
+    "name": "Springtide Storm",
+    "effect": "O usuário ataca envolvendo os Pokémon adversários em ventos ferozes repletos de amor e ódio. Este movimento tem 30% de chance de reduzir os atributos de Ataque dos Pokémon adversários."
   },
   "mysticalPower": {
     "name": "Mystical Power",
     "effect": "O usuário ataca emitindo um poder misterioso. Isso também aumenta o atributo de Atq. Esp. do usuário."
   },
   "ragingFury": {
-    "name": "Raging Fury"
+    "name": "Raging Fury",
+    "effect": "O usuário se descontrola cuspindo chamas por 2 a 3 turnos. O usuário então fica confuso."
   },
   "waveCrash": {
-    "name": "Wave Crash"
+    "name": "Wave Crash",
+    "effect": "O usuário se envolve em água e se choca contra o alvo com todo o corpo para causar dano. O usuário recebe um terço do dano causado por este movimento."
   },
   "chloroblast": {
-    "name": "Chloroblast"
+    "name": "Chloroblast",
+    "effect": "O usuário lança sua clorofila acumulada para causar dano ao alvo. Após atacar, o usuário recebe dano igual à metade de seus PS máximos."
   },
   "mountainGale": {
-    "name": "Mountain Gale"
+    "name": "Mountain Gale",
+    "effect": "O usuário arremessa blocos gigantes de gelo no alvo para causar dano. Este movimento tem 30% de chance de fazer o alvo hesitar."
   },
   "victoryDance": {
     "name": "Victory Dance",
@@ -2762,10 +3352,12 @@
     "effect": "O usuário se choca contra o alvo em um ataque de corpo inteiro. Isso também diminui os atributos de Defesa e Def. Esp. do usuário."
   },
   "barbBarrage": {
-    "name": "Barb Barrage"
+    "name": "Barb Barrage",
+    "effect": "O usuário lança incontáveis farpas tóxicas para causar dano. Este movimento tem 50% de chance de envenenar o alvo. O poder deste movimento é duplicado se o alvo já estiver envenenado."
   },
   "esperWing": {
-    "name": "Esper Wing"
+    "name": "Esper Wing",
+    "effect": "O usuário corta o alvo com asas enriquecidas por aura, aumentando seu atributo de Velocidade. A taxa de golpe crítico deste movimento também é aumentada em 1 estágio."
   },
   "bitterMalice": {
     "name": "Bitter Malice",
@@ -2776,23 +3368,28 @@
     "effect": "O usuário torna sua pele tão dura quanto um escudo de ferro, aumentando muito seu atributo de Defesa."
   },
   "tripleArrows": {
-    "name": "Triple Arrows"
+    "name": "Triple Arrows",
+    "effect": "O usuário chuta e então dispara três flechas. Este movimento tem 50% de chance de reduzir o atributo de Defesa do alvo e 30% de chance de fazer o alvo hesitar. A taxa de golpe crítico deste movimento também é aumentada em 1 estágio."
   },
   "infernalParade": {
     "name": "Infernal Parade",
     "effect": "O usuário ataca com uma infinidade de bolas de fogo. Esse movimento tem 30% de chance de causar queimadura no alvo. O poder desse movimento é duplicado se o alvo estiver sob o efeito de uma condição de status."
   },
   "ceaselessEdge": {
-    "name": "Ceaseless Edge"
+    "name": "Ceaseless Edge",
+    "effect": "O usuário desfere uma lâmina afiada contra o alvo, deixando lascas sob o alvo como espinhos. Pokémon que entrarem na batalha recebem dano igual a um oitavo de seus PS máximos. Até três camadas podem ser armadas, com cada camada aumentando o dano recebido. Tipos Voadores ou Pokémon com Levitate não são afetados por esses espinhos."
   },
   "bleakwindStorm": {
-    "name": "Bleakwind Storm"
+    "name": "Bleakwind Storm",
+    "effect": "O usuário ataca com ventos selvagemente gelados que fazem tanto o corpo quanto o espírito tremerem. Este movimento tem 30% de chance de reduzir os atributos de Velocidade dos Pokémon adversários e nunca erra na chuva."
   },
   "wildboltStorm": {
-    "name": "Wildbolt Storm"
+    "name": "Wildbolt Storm",
+    "effect": "O usuário invoca uma tempestade trovejante e ataca selvagemente com relâmpagos e vento. Este movimento tem 20% de chance de paralisar os alvos e nunca erra na chuva."
   },
   "sandsearStorm": {
-    "name": "Sandsear Storm"
+    "name": "Sandsear Storm",
+    "effect": "O usuário ataca envolvendo os Pokémon adversários em ventos ferozes e areia escaldante. Este movimento tem 20% de chance de causar queimadura nos alvos e nunca erra na chuva."
   },
   "lunarBlessing": {
     "name": "Lunar Blessing",
@@ -2803,7 +3400,8 @@
     "effect": "O usuário levanta o ânimo, curando suas próprias condições de status e aumentando seus atributos de Ata. Esp. e Def. Esp."
   },
   "gMaxWildfire": {
-    "name": "G-Max Wildfire"
+    "name": "G-Max Wildfire",
+    "effect": "Um ataque do tipo Fogo que os Charizard Gigantamax usam. Por 4 turnos, este movimento continua a causar dano aos oponentes que não sejam do tipo Fogo igual a um sexto de seus PS máximos ao final de cada turno."
   },
   "gMaxBefuddle": {
     "name": "G-Max Befuddle",
@@ -2818,50 +3416,60 @@
     "effect": "Um ataque do tipo Normal que o Gigantamax Meowth usa. Este movimento confunde os oponentes e também ganha dinheiro extra."
   },
   "gMaxChiStrike": {
-    "name": "G-Max Chi Strike"
+    "name": "G-Max Chi Strike",
+    "effect": "Um ataque do tipo Lutador que os Machamp Gigantamax usam. Este movimento anima o usuário e seus aliados, aumentando a taxa de golpe crítico dos movimentos em 1 estágio."
   },
   "gMaxTerror": {
     "name": "G-Max Terror",
     "effect": "Um ataque do tipo Fantasma que Gigantamax Gengar usa. Este Pokémon pisa na sombra do Pokémon adversário para impedi-lo de escapar."
   },
   "gMaxResonance": {
-    "name": "G-Max Resonance"
+    "name": "G-Max Resonance",
+    "effect": "Um ataque do tipo Gelo que os Lapras Gigantamax usam. Este movimento reduz pela metade o dano recebido de movimentos físicos e especiais por 5 turnos."
   },
   "gMaxCuddle": {
     "name": "G-Max Cuddle",
     "effect": "Um ataque do tipo Normal que Gigantamax Eevee usa. Este movimento apaixona os oponentes."
   },
   "gMaxReplenish": {
-    "name": "G-Max Replenish"
+    "name": "G-Max Replenish",
+    "effect": "Um ataque do tipo Normal que os Snorlax Gigantamax usam. Este movimento tem 50% de chance de restaurar Frutas consumidas pelo usuário ou seus aliados."
   },
   "gMaxMalodor": {
     "name": "G-Max Malodor",
     "effect": "Um ataque do tipo Venenoso que Gigantamax Garbodor usa. Este movimento envenena os oponentes."
   },
   "gMaxStonesurge": {
-    "name": "G-Max Stonesurge"
+    "name": "G-Max Stonesurge",
+    "effect": "Um ataque do tipo Água que os Drednaw Gigantamax usam. Este movimento espalha pedras afiadas pelo campo, causando dano aos Pokémon adversários que entrarem na batalha igual a um oitavo de seus PS máximos. Esse dano varia dependendo da compatibilidade de tipo do Pokémon com o tipo Pedra."
   },
   "gMaxWindRage": {
-    "name": "G-Max Wind Rage"
+    "name": "G-Max Wind Rage",
+    "effect": "Um ataque do tipo Voador que os Corviknight Gigantamax usam. Este movimento remove as barreiras do alvo, como Light Screen, Reflect, Aurora Veil ou Safeguard, bem como quaisquer armadilhas ou terreno do campo. Isso também pode dissipar névoa densa."
   },
   "gMaxStunShock": {
     "name": "G-Max Stun Shock",
     "effect": "Um ataque do tipo Elétrico que Gigantamax Toxtricity usa. Este movimento envenena ou paralisa os oponentes."
   },
   "gMaxFinale": {
-    "name": "G-Max Finale"
+    "name": "G-Max Finale",
+    "effect": "Um ataque do tipo Fada que os Alcremie Gigantamax usam. Este movimento restaura um sexto dos PS máximos do usuário e de seus aliados."
   },
   "gMaxDepletion": {
-    "name": "G-Max Depletion"
+    "name": "G-Max Depletion",
+    "effect": "Um ataque do tipo Dragão que os Duraludon Gigantamax usam. Reduz em 2 os PP do último movimento usado pelo alvo."
   },
   "gMaxGravitas": {
-    "name": "G-Max Gravitas"
+    "name": "G-Max Gravitas",
+    "effect": "Um ataque do tipo Psíquico que os Orbeetle Gigantamax usam. Este movimento altera a gravidade por 5 turnos, aumentando a precisão dos movimentos em 67% e trazendo para o chão os tipos Voadores ou Pokémon com Levitate."
   },
   "gMaxVolcalith": {
-    "name": "G-Max Volcalith"
+    "name": "G-Max Volcalith",
+    "effect": "Um ataque do tipo Pedra que os Coalossal Gigantamax usam. Por 4 turnos, este movimento continua a causar dano aos oponentes que não sejam do tipo Pedra igual a um sexto de seus PS máximos ao final de cada turno."
   },
   "gMaxSandblast": {
-    "name": "G-Max Sandblast"
+    "name": "G-Max Sandblast",
+    "effect": "Um ataque do tipo Terrestre que os Sandaconda Gigantamax usam. Os oponentes ficam presos em uma tempestade de areia furiosa que causa dano igual a um oitavo de seus PS máximos por 4 a 5 turnos."
   },
   "gMaxSnooze": {
     "name": "G-Max Snooze",
@@ -2880,7 +3488,8 @@
     "effect": "Um ataque do tipo Fada que Gigantamax Hatterene usa. Este movimento confunde os oponentes."
   },
   "gMaxSteelsurge": {
-    "name": "G-Max Steelsurge"
+    "name": "G-Max Steelsurge",
+    "effect": "Um ataque do tipo Aço que os Copperajah Gigantamax usam. Este movimento espalha espinhos afiados pelo campo, causando dano aos Pokémon adversários que entrarem na batalha igual a um oitavo de seus PS máximos. Esse dano varia dependendo da compatibilidade de tipo do Pokémon com o tipo Aço."
   },
   "gMaxMeltdown": {
     "name": "G-Max Meltdown",
@@ -2891,48 +3500,60 @@
     "effect": "Um ataque do tipo Água usado pelo Gigantamax Kingler. Este movimento reduz drasticamente a Velocidade dos adversários."
   },
   "gMaxCentiferno": {
-    "name": "G-Max Centiferno"
+    "name": "G-Max Centiferno",
+    "effect": "Um ataque do tipo Fogo que os Centiskorch Gigantamax usam. Por 4 a 5 turnos, este movimento prende os oponentes em chamas que causam dano igual a um oitavo de seus PS máximos ao final de cada turno."
   },
   "gMaxVineLash": {
-    "name": "G-Max Vine Lash"
+    "name": "G-Max Vine Lash",
+    "effect": "Um ataque do tipo Grama que os Venusaur Gigantamax usam. Por 4 turnos, este movimento continua a causar dano aos oponentes que não sejam do tipo Grama igual a um sexto de seus PS máximos ao final de cada turno."
   },
   "gMaxCannonade": {
-    "name": "G-Max Cannonade"
+    "name": "G-Max Cannonade",
+    "effect": "Um ataque do tipo Água que os Blastoise Gigantamax usam. Por 4 turnos, este movimento continua a causar dano aos oponentes que não sejam do tipo Água igual a um sexto de seus PS máximos ao final de cada turno."
   },
   "gMaxDrumSolo": {
-    "name": "G-Max Drum Solo"
+    "name": "G-Max Drum Solo",
+    "effect": "Um ataque do tipo Grama que os Rillaboom Gigantamax usam. Este movimento pode ignorar o efeito da Habilidade do alvo (com certas exceções)."
   },
   "gMaxFireball": {
-    "name": "G-Max Fireball"
+    "name": "G-Max Fireball",
+    "effect": "Um ataque do tipo Fogo que os Cinderace Gigantamax usam. Este movimento pode ignorar o efeito da Habilidade do alvo (com certas exceções)."
   },
   "gMaxHydrosnipe": {
-    "name": "G-Max Hydrosnipe"
+    "name": "G-Max Hydrosnipe",
+    "effect": "Um ataque do tipo Água que os Inteleon Gigantamax usam. Este movimento pode ignorar o efeito da Habilidade do alvo (com certas exceções)."
   },
   "gMaxOneBlow": {
-    "name": "G-Max One Blow"
+    "name": "G-Max One Blow",
+    "effect": "Um ataque do tipo Sombrio que os Urshifu Gigantamax usam. Este movimento de golpe único pode atingir um alvo que esteja usando um movimento como Protect ou Detect."
   },
   "gMaxRapidFlow": {
-    "name": "G-Max Rapid Flow"
+    "name": "G-Max Rapid Flow",
+    "effect": "Um ataque do tipo Água que os Urshifu Gigantamax usam. Este movimento de golpes rápidos pode atingir um alvo que esteja usando um movimento como Protect ou Detect."
   },
   "teraBlast": {
     "name": "Tera Blast",
     "effect": "Se o usuário estiver Terastalizado, ele libera energia de seu Tera Tipo. Este movimento causa dano usando o maior entre o Ataque ou Ataque Esp. do usuário."
   },
   "silkTrap": {
-    "name": "Silk Trap"
+    "name": "Silk Trap",
+    "effect": "O usuário tece uma armadilha de seda, protegendo-se de dano enquanto reduz o atributo de Velocidade de qualquer atacante que faça contato direto. A cada uso consecutivo, a chance de sucesso deste movimento se torna um terço do que era antes."
   },
   "axeKick": {
-    "name": "Axe Kick"
+    "name": "Axe Kick",
+    "effect": "O usuário ataca chutando para o alto e baixando o calcanhar sobre o alvo. Este movimento tem 30% de chance de confundir o alvo. Se este movimento errar ou falhar, o usuário recebe dano igual à metade de seus PS máximos."
   },
   "lastRespects": {
-    "name": "Last Respects"
+    "name": "Last Respects",
+    "effect": "O usuário ataca para vingar seus aliados. O poder deste movimento é aumentado em 50 para cada vez que um Pokémon na equipe do usuário tenha desmaiado."
   },
   "luminaCrash": {
     "name": "Lumina Crash",
     "effect": "O usuário ataca liberando uma luz peculiar que afeta até a mente. Isso também reduz muito a Defesa Esp. do alvo."
   },
   "orderUp": {
-    "name": "Order Up"
+    "name": "Order Up",
+    "effect": "O usuário ataca com elegante postura. Se o usuário tiver um Tatsugiri em sua boca, este movimento aumenta os atributos do usuário com base na forma do Tatsugiri: Ataque para o Tatsugiri Curly, Defesa para o Droopy ou Velocidade para o Stretchy."
   },
   "jetPunch": {
     "name": "Jet Punch",
@@ -2947,7 +3568,8 @@
     "effect": "O usuário gira furiosamente, tensionando as pernas, causando dano ao alvo. Isso também reduz muito o atributo de Velocidade do usuário."
   },
   "populationBomb": {
-    "name": "Population Bomb"
+    "name": "Population Bomb",
+    "effect": "Os companheiros do usuário se reúnem em massa para realizar um ataque combinado que atinge o alvo de 1 a 10 vezes seguidas. O ataque termina se o usuário errar."
   },
   "iceSpinner": {
     "name": "Ice Spinner",
@@ -2962,20 +3584,24 @@
     "effect": "O usuário concede uma bênção amorosa, reanimando um Pokémon da equipe que tenha desmaiado e restaurando metade do máximo de PS desse Pokémon."
   },
   "saltCure": {
-    "name": "Salt Cure"
+    "name": "Salt Cure",
+    "effect": "O usuário cura o alvo com sal, causando dano igual a um dezesseis avos dos PS máximos do alvo ao final de cada turno. Tipos Aço e Água recebem dano igual a um oitavo de seus PS máximos."
   },
   "tripleDive": {
-    "name": "Triple Dive"
+    "name": "Triple Dive",
+    "effect": "O usuário realiza um mergulho triplo perfeitamente cronometrado, atingindo o alvo com jatos de água 3 vezes seguidas."
   },
   "mortalSpin": {
-    "name": "Mortal Spin"
+    "name": "Mortal Spin",
+    "effect": "O usuário realiza um ataque giratório que pode eliminar os efeitos de movimentos que prendem e de Leech Seed, bem como quaisquer armadilhas em seu lado do campo. Isso também envenena os Pokémon adversários."
   },
   "doodle": {
     "name": "Doodle",
     "effect": "O usuário captura a essência do alvo em um esboço. Isso muda as Habilidades do usuário e de seus Pokémon aliados para a do alvo."
   },
   "filletAway": {
-    "name": "Fillet Away"
+    "name": "Fillet Away",
+    "effect": "O usuário perde metade de seus PS máximos para aumentar bruscamente seus atributos de Ataque, Ataque Especial e Velocidade. Este movimento falha se o usuário não tiver PS restantes suficientes."
   },
   "kowtowCleave": {
     "name": "Kowtow Cleave",
@@ -2994,38 +3620,48 @@
     "effect": "O usuário brinca com o alvo e o ataca usando passos de dança leves e fluidos. Isso também aumenta a Velocidade do usuário."
   },
   "ragingBull": {
-    "name": "Raging Bull"
+    "name": "Raging Bull",
+    "effect": "O usuário realiza uma investida como um touro furioso. Ele também pode quebrar barreiras, como Light Screen e Reflect. Quando usado por Tauros, o tipo deste movimento muda dependendo de sua forma."
   },
   "makeItRain": {
-    "name": "Make It Rain"
+    "name": "Make It Rain",
+    "effect": "O usuário ataca arremessando uma massa de moedas. Isso reduz duramente o atributo de Ataque Especial do usuário. Se um alvo for atingido com sucesso, você ganhará dinheiro após a batalha."
   },
   "psyblade": {
-    "name": "Psyblade"
+    "name": "Psyblade",
+    "effect": "O usuário rasga o alvo com uma lâmina etérea. O poder deste movimento é aumentado em 50% se o usuário estiver no Terreno Elétrico."
   },
   "hydroSteam": {
-    "name": "Hydro Steam"
+    "name": "Hydro Steam",
+    "effect": "O usuário atinge o alvo com água fervente. O poder deste movimento não é reduzido sob sol forte, mas sim aumentado em 50%."
   },
   "ruination": {
-    "name": "Ruination"
+    "name": "Ruination",
+    "effect": "O usuário invoca um desastre ruinoso. Isso causa ao alvo dano igual à metade de seus PS restantes."
   },
   "collisionCourse": {
-    "name": "Collision Course"
+    "name": "Collision Course",
+    "effect": "O usuário avança e se choca contra o chão, causando uma enorme explosão pré-histórica. O poder deste movimento é aumentado em 33% se for um acerto supereficaz."
   },
   "electroDrift": {
-    "name": "Electro Drift"
+    "name": "Electro Drift",
+    "effect": "O usuário avança em velocidades ultrarrápidas, perfurando seu alvo com eletricidade futurista. O poder deste movimento é aumentado em 33% se for um acerto supereficaz."
   },
   "shedTail": {
-    "name": "Shed Tail"
+    "name": "Shed Tail",
+    "effect": "O usuário cria um substituto de si mesmo usando metade de seus PS máximos antes de trocar de lugar com um Pokémon da equipe que esteja aguardando."
   },
   "chillyReception": {
-    "name": "Chilly Reception"
+    "name": "Chilly Reception",
+    "effect": "O usuário conta uma piada arrepiantemente ruim antes de trocar de lugar com um Pokémon da equipe que esteja aguardando. Isso invoca uma nevasca que dura 5 turnos."
   },
   "tidyUp": {
     "name": "Tidy Up",
     "effect": "O usuário limpa e remove os efeitos de Spikes, Stealth Rock, Sticky Web, Toxic Spikes, e Substitute. Isso também aumenta os atributos de Ataque e Velocidade do usuário."
   },
   "snowscape": {
-    "name": "Snowscape"
+    "name": "Snowscape",
+    "effect": "O usuário invoca uma nevasca que dura 5 turnos. Isso aumenta os atributos de Defesa dos tipos Gelo."
   },
   "pounce": {
     "name": "Pounce",
@@ -3048,84 +3684,104 @@
     "effect": "O usuário dispara feixes místicos de seus olhos para causar dano. O alvo é atingido duas vezes seguidas."
   },
   "rageFist": {
-    "name": "Rage Fist"
+    "name": "Rage Fist",
+    "effect": "O usuário ataca convertendo sua fúria em energia. O poder deste movimento é aumentado em 50 cada vez que o usuário recebe dano de um movimento, até um poder máximo de 350. Se o usuário for trocado da batalha, o poder do movimento retorna ao seu valor habitual."
   },
   "armorCannon": {
-    "name": "Armor Cannon"
+    "name": "Armor Cannon",
+    "effect": "O usuário ataca disparando sua própria armadura como projéteis flamejantes. Isso também reduz os atributos de Defesa e Defesa Especial do usuário."
   },
   "bitterBlade": {
-    "name": "Bitter Blade"
+    "name": "Bitter Blade",
+    "effect": "O usuário ataca concentrando todos os seus sentimentos amargos por este mundo em um ataque cortante. Os PS do usuário são restaurados em metade do dano causado por este movimento."
   },
   "doubleShock": {
-    "name": "Double Shock"
+    "name": "Double Shock",
+    "effect": "O usuário descarrega toda a eletricidade de seu corpo para realizar um ataque de alto dano e perde o tipo Elétrico. Este movimento falha a menos que seja usado por um tipo Elétrico."
   },
   "gigatonHammer": {
     "name": "Gigaton Hammer",
     "effect": "O usuário balança todo o seu corpo para atacar com seu enorme martelo. Este movimento não pode ser usado duas vezes seguidas."
   },
   "comeuppance": {
-    "name": "Comeuppance"
+    "name": "Comeuppance",
+    "effect": "O usuário revida para causar 1,5 vez o dano que recebeu do movimento de um oponente durante o turno em que este movimento é usado."
   },
   "aquaCutter": {
-    "name": "Aqua Cutter"
+    "name": "Aqua Cutter",
+    "effect": "O usuário expele água pressurizada para cortar o alvo como uma lâmina. A taxa de golpe crítico deste movimento é aumentada em 1 estágio."
   },
   "blazingTorque": {
-    "name": "Blazing Torque"
+    "name": "Blazing Torque",
+    "effect": "O usuário se choca contra o alvo com energia flamejante. Este movimento tem 30% de chance de causar queimadura no alvo."
   },
   "wickedTorque": {
-    "name": "Wicked Torque"
+    "name": "Wicked Torque",
+    "effect": "O usuário se choca contra o alvo com intenção maliciosa. Este movimento tem 10% de chance de fazer o alvo dormir."
   },
   "noxiousTorque": {
-    "name": "Noxious Torque"
+    "name": "Noxious Torque",
+    "effect": "O usuário se choca contra o alvo com um final venenoso. Este movimento tem 30% de chance de envenenar o alvo."
   },
   "combatTorque": {
-    "name": "Combat Torque"
+    "name": "Combat Torque",
+    "effect": "O usuário se choca contra o alvo com grande força. Este movimento tem 30% de chance de paralisar o alvo."
   },
   "magicalTorque": {
-    "name": "Magical Torque"
+    "name": "Magical Torque",
+    "effect": "O usuário se choca contra o alvo com uma força feérica. Este movimento tem 30% de chance de confundir o alvo."
   },
   "bloodMoon": {
     "name": "Blood Moon",
     "effect": "O usuário libera toda a força de seu espírito de uma lua cheia que brilha tão vermelha quanto o sangue. Este movimento não pode ser usado duas vezes seguidas."
   },
   "matchaGotcha": {
-    "name": "Matcha Gotcha"
+    "name": "Matcha Gotcha",
+    "effect": "O usuário dispara uma rajada de chá que misturou. Os PS do usuário são restaurados em metade do dano causado por este movimento, e ele tem 20% de chance de causar queimadura nos alvos. Isso também descongelará um usuário ou alvo congelado."
   },
   "syrupBomb": {
-    "name": "Syrup Bomb"
+    "name": "Syrup Bomb",
+    "effect": "O usuário desencadeia uma explosão de calda de doce pegajosa, que reveste o alvo e faz o atributo de Velocidade do alvo cair ao final de cada turno por 3 turnos."
   },
   "ivyCudgel": {
-    "name": "Ivy Cudgel"
+    "name": "Ivy Cudgel",
+    "effect": "O usuário golpeia com um porrete envolto em hera; a taxa de golpe crítico deste movimento é aumentada em 1 estágio. Quando usado por Ogerpon, o tipo deste movimento muda dependendo da máscara usada."
   },
   "electroShot": {
     "name": "Electro Shot",
     "effect": "O usuário acumula eletricidade no primeiro turno, aumentando suo atributo de Ataque Esp., e então dispara um tiro de alta voltagem no próximo turno. O tiro será disparado imediatamente na chuva."
   },
   "teraStarstorm": {
-    "name": "Tera Starstorm"
+    "name": "Tera Starstorm",
+    "effect": "Com o poder de seus cristais, o usuário bombardeia e elimina o alvo. Quando usado por Terapagos em sua Forma Estelar, este movimento causa dano a todos os Pokémon adversários. Este movimento causa dano usando o atributo de Ataque ou Ataque Especial — o que for maior para o usuário quando Terastalizado."
   },
   "fickleBeam": {
-    "name": "Fickle Beam"
+    "name": "Fickle Beam",
+    "effect": "O usuário dispara um feixe de luz para causar dano. Há 30% de chance de que todas as cabeças do usuário disparem feixes em uníssono, duplicando o poder do movimento."
   },
   "burningBulwark": {
-    "name": "Burning Bulwark"
+    "name": "Burning Bulwark",
+    "effect": "O usuário aquece intensamente uma parte de seu corpo, protegendo-a de ataques e também causando queimaduras a qualquer atacante que faça contato direto com ela."
   },
   "thunderclap": {
     "name": "Thunderclap",
     "effect": "Este movimento permite que o usuário ataque primeiro com um choque de eletricidade. Este movimento falha se o alvo não estiver preparando um ataque."
   },
   "mightyCleave": {
-    "name": "Mighty Cleave"
+    "name": "Mighty Cleave",
+    "effect": "O usuário maneja a luz acumulada em suas lâminas para cortar o alvo. Este movimento acerta mesmo se o alvo se proteger."
   },
   "tachyonCutter": {
     "name": "Tachyon Cutter",
     "effect": "O usuário ataca lançando lâminas de partículas no alvo duas vezes seguidas. Este ataque nunca erra."
   },
   "hardPress": {
-    "name": "Hard Press"
+    "name": "Hard Press",
+    "effect": "O alvo é esmagado com um braço, uma garra ou algo do tipo para causar dano. Quanto mais PS o alvo tiver, maior o poder do movimento (variando entre 1 e 100)."
   },
   "dragonCheer": {
-    "name": "Dragon Cheer"
+    "name": "Dragon Cheer",
+    "effect": "O usuário eleva o moral de seus aliados com um grito dracônico para que seus ataques futuros tenham uma chance maior de acertar golpes críticos. Os tipos Dragão recebem um aumento de 2 estágios. Todos os outros tipos recebem um aumento de 1 estágio."
   },
   "alluringVoice": {
     "name": "Alluring Voice",
@@ -3136,17 +3792,20 @@
     "effect": "Impulsionado pelo desespero, o usuário ataca o alvo. O poder deste movimento é dobrado se o movimento anterior do usuário tiver falhado."
   },
   "supercellSlam": {
-    "name": "Supercell Slam"
+    "name": "Supercell Slam",
+    "effect": "O usuário eletrifica seu corpo e cai sobre o alvo para causar dano. O usuário recebe dano igual à metade de seus PS máximos se este movimento errar ou falhar. Se o alvo tiver usado Minimize, o poder deste movimento é duplicado e ele sempre acertará."
   },
   "psychicNoise": {
-    "name": "Psychic Noise"
+    "name": "Psychic Noise",
+    "effect": "O usuário ataca o alvo com ondas sonoras desagradáveis. Por 2 turnos, o alvo fica impedido de recuperar PS por meio de movimentos, Habilidades ou itens segurados."
   },
   "upperHand": {
     "name": "Upper Hand",
     "effect": "O usuário reage ao movimento do alvo e o ataca com o calcanhar da palma da mão, fazendo o alvo hesitar. Este movimento falha se o alvo não estiver preparando um movimento de prioridade."
   },
   "malignantChain": {
-    "name": "Malignant Chain"
+    "name": "Malignant Chain",
+    "effect": "O usuário despeja toxinas no alvo envolvendo-o em uma corrente tóxica e corrosiva. Este movimento tem 50% de chance de envenenar gravemente o alvo."
   },
   "nihilLight": {
     "name": "Nihil Light",


### PR DESCRIPTION
## Explanation of Changes
- Main repo PR: N/A
- Adds Brazilian Portuguese effect descriptions for moves in `pt-BR/move.json`.
- Improves move localization coverage without adding, removing, or renaming locale keys.

## Screenshots/Videos
N/A - localization text update only.

## Checklist
- [x] I have provided **screenshots** proving my additions are properly working (if necessary).
- [x] I have attached a link to a main repo PR or properly explained my changes as applicable.
- [x] I have notified Translation staff on Discord about the existence of this PR.
- [x] I have uncommented the appropriate warning message if necessary.