### PR TITLE
Add key for setting to override pokedex unlocks locally

### DIFF
--- a/en/settings.json
+++ b/en/settings.json
@@ -139,5 +139,6 @@
   "checkTeam": "Check Team",
   "confirmDisableTouch": "Are you sure you want to disable Touch Controls?",
   "defaultConfirmMessage": "Are you sure?",
-  "alwaysPromptMessages": "Always Prompt for Messages"
+  "alwaysPromptMessages": "Always Prompt for Messages",
+  "dexForDevs": "Full Pokédex Unlocks (Dev)"
 }


### PR DESCRIPTION
## Explanation of Changes
The setting to override pokedex unlocks locally never had a locales key added for it, so this PR is made to add one.
- Main repo PR: N/A

## Screenshots/Videos
<details><summary>Screenshot</summary>

<img width="1228" height="690" alt="image" src="https://github.com/user-attachments/assets/bcdb1c8c-f6d6-46cb-870a-717911fe56a8" />

</details> 

## Checklist
- [x] I have provided **screenshots** proving my additions are properly working (if necessary).
- [x] I have attached a link to a main repo PR or properly explained my changes as applicable.
- [x] I have notified Translation staff on Discord about the existence of this PR.
- [x] I have uncommented the appropriate warning message if necessary.
