### PR TITLE
Add "configure" key used when moving touch controls

### DIFF
--- a/en/settings.json
+++ b/en/settings.json
@@ -130,6 +130,7 @@
   "orientation": "Orientation:",
   "landscape": "Landscape",
   "portrait": "Portrait",
+  "configure": "Configure",
   "shopOverlayOpacity": "Shop Overlay Opacity",
   "shopCursorTarget": "Shop Cursor Target",
   "commandCursorMemory": "Battle Cursor Memory",


### PR DESCRIPTION
## Explanation of Changes
Added a "configure" key used when moving the touch controls in the settings.
- Main repo PR: https://github.com/pagefaultgames/pokerogue/pull/7533

## Screenshots/Videos
<details><summary>Screenshot</summary>

<img width="707" height="392" alt="image" src="https://github.com/user-attachments/assets/c069a5d2-8a7d-424b-b614-4a9ef2b4b996" />

</details> 

## Checklist
- [x] I have provided **screenshots** proving my additions are properly working (if necessary).
- [x] I have attached a link to a main repo PR or properly explained my changes as applicable.
- [x] I have notified Translation staff on Discord about the existence of this PR.
- ~[ ] I have uncommented the appropriate warning message if necessary.~
