### PR TITLE
dev: add Biome and TypeScript, update scripts and workflows

### DIFF
--- a/.github/scripts/helpers/strings.js
+++ b/.github/scripts/helpers/strings.js
@@ -1,4 +1,5 @@
-// #region Split string code
+// #region String splitting
+
 // Regexps involved with splitting words in various case formats.
 // Sourced from https://www.npmjs.com/package/change-case (with slight tweaking here and there)
 
@@ -22,7 +23,7 @@ const SPLIT_REPLACE_VALUE = "$1\0$2";
 
 /**
  * Split any cased string into an array of its constituent words.
- * @param {string} value
+ * @param {string} value - The string to be split
  * @returns {string[]} The new string, delimited at each instance of one or more spaces, underscores, hyphens
  * or lower-to-upper boundaries.
  */
@@ -30,6 +31,7 @@ function splitWords(value) {
   let result = value.trim();
   result = result.replace(SPLIT_LOWER_UPPER_RE, SPLIT_REPLACE_VALUE).replace(SPLIT_UPPER_UPPER_RE, SPLIT_REPLACE_VALUE);
   result = result.replace(DELIM_STRIP_REGEXP, "\0");
+
   // Trim the delimiter from around the output string
   return trimFromStartAndEnd(result, "\0").split(/\0/g);
 }
@@ -38,12 +40,13 @@ function splitWords(value) {
  * Helper function to remove one or more sequences of characters from either end of a string.
  * @param {string} str - The string to replace
  * @param {string} charToTrim - The string to remove
- * @returns {string} The string having been trimmed
+ * @returns {string} The result of removing all instances of {@linkcode charToTrim} from either end of {@linkcode str}.
  */
 function trimFromStartAndEnd(str, charToTrim) {
   let start = 0;
   let end = str.length;
   const blockLength = charToTrim.length;
+
   while (str.startsWith(charToTrim, start)) {
     start += blockLength;
   }
@@ -56,29 +59,45 @@ function trimFromStartAndEnd(str, charToTrim) {
   }
   return str.slice(start, end);
 }
-// #endregion Split String code
+
+// #endregion String splitting
+
+// #region String casing
 
 /**
  * Capitalize the first letter of a string.
+ * @param {string} str - The string whose first letter is to be capitalized
+ * @returns {string} The original string with its first letter capitalized.
  * @example
  * ```ts
  * console.log(capitalizeFirstLetter("consectetur adipiscing elit")); // returns "Consectetur adipiscing elit"
  * ```
- * @param {string} str - The string whose first letter is to be capitalized
- * @return {string} The original string with its first letter capitalized.
  */
 export function capitalizeFirstLetter(str) {
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
 /**
+ * Capitalize the first letter of a string, and make the rest lowercase.
+ * @param {string} str - The string to transform
+ * @returns {string} The original string with all letters lowercase except the first which is capitalized
+ * @example
+ * ```ts
+ * console.log(capitalizeFirstLetterOnly("WATER")); // prints "Water"
+ * ```
+ */
+export function capitalizeFirstLetterOnly(str) {
+  return capitalizeFirstLetter(str.toLowerCase());
+}
+
+/**
  * Helper method to convert a string into `Title Case` (such as one used for console logs).
+ * @param {string} str - The string being converted
+ * @returns {string} The result of converting `str` into title case.
  * @example
  * ```ts
  * console.log(toTitleCase("lorem ipsum dolor sit amet")); // returns "Lorem Ipsum Dolor Sit Amet"
  * ```
- * @param {string} str - The string being converted
- * @returns {string} The result of converting `str` into title case.
  */
 export function toTitleCase(str) {
   return splitWords(str)
@@ -88,12 +107,12 @@ export function toTitleCase(str) {
 
 /**
  * Helper method to convert a string into `camelCase` (such as one used for i18n keys).
+ * @param {string} str - The string being converted
+ * @returns {string} The result of converting `str` into camel case.
  * @example
  * ```ts
  * console.log(toCamelCase("BIG_ANGRY_TRAINER")); // returns "bigAngryTrainer"
  * ```
- * @param {string} str - The string being converted
- * @returns {string} The result of converting `str` into camel case.
  */
 export function toCamelCase(str) {
   return splitWords(str)
@@ -105,12 +124,12 @@ export function toCamelCase(str) {
 
 /**
  * Helper method to convert a string into `PascalCase`.
+ * @param {string} str - The string being converted
+ * @returns {string} The result of converting `str` into pascal case.
  * @example
  * ```ts
  * console.log(toPascalCase("hi how was your day")); // returns "HiHowWasYourDay"
  * ```
- * @param {string} str - The string being converted
- * @returns {string} The result of converting `str` into pascal case.
  */
 export function toPascalCase(str) {
   return splitWords(str)
@@ -120,12 +139,12 @@ export function toPascalCase(str) {
 
 /**
  * Helper method to convert a string into `kebab-case` (such as one used for filenames).
+ * @param {string} str - The string being converted
+ * @returns {string} The result of converting `str` into kebab case.
  * @example
  * ```ts
  * console.log(toKebabCase("not_kebab-caSe String")); // returns "not-kebab-case-string"
  * ```
- * @param {string} str - The string being converted
- * @returns {string} The result of converting `str` into kebab case.
  */
 export function toKebabCase(str) {
   return splitWords(str)
@@ -135,12 +154,12 @@ export function toKebabCase(str) {
 
 /**
  * Helper method to convert a string into `snake_case` (such as one used for filenames).
+ * @param {string} str - The string being converted
+ * @returns {string} The result of converting `str` into snake case.
  * @example
  * ```ts
  * console.log(toSnakeCase("not-in snake_CaSe")); // returns "not_in_snake_case"
  * ```
- * @param {string} str - The string being converted
- * @returns {string} The result of converting `str` into snake case.
  */
 export function toSnakeCase(str) {
   return splitWords(str)
@@ -150,12 +169,12 @@ export function toSnakeCase(str) {
 
 /**
  * Helper method to convert a string into `UPPER_SNAKE_CASE`.
+ * @param {string} str - The string being converted
+ * @returns {string} The result of converting `str` into upper snake case.
  * @example
  * ```ts
  * console.log(toUpperSnakeCase("apples bananas_oranGes-PearS")); // returns "APPLES_BANANAS_ORANGES_PEARS"
  * ```
- * @param {string} str - The string being converted
- * @returns {string} The result of converting `str` into upper snake case.
  */
 export function toUpperSnakeCase(str) {
   return splitWords(str)
@@ -165,15 +184,39 @@ export function toUpperSnakeCase(str) {
 
 /**
  * Helper method to convert a string into `Pascal_Snake_Case`.
+ * @param {string} str - The string being converted
+ * @returns {string} The result of converting `str` into pascal snake case.
  * @example
  * ```ts
  * console.log(toPascalSnakeCase("apples-bananas_oranGes Pears")); // returns "Apples_Bananas_Oranges_Pears"
  * ```
- * @param {string} str - The string being converted
- * @returns {string} The result of converting `str` into pascal snake case.
  */
 export function toPascalSnakeCase(str) {
   return splitWords(str)
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
     .join("_");
+}
+
+// #endregion String casing
+
+/**
+ * Chunk a string into an array, creating a new element every `length` characters.
+ * @param {string} str - The string to chunk
+ * @param {number} length - The length of each chunk; should be a non-negative integer
+ * @returns {string[]} The result of splitting `str` after every instance of `length` characters.
+ * @example
+ * ```ts
+ * console.log(chunkString("123456789abc", 4)); // Output: ["1234", "5678", "9abc"]
+ * console.log(chunkString("1234567890", 4)); // Output: ["1234", "5678", "90"]
+ * ```
+ */
+export function chunkString(str, length) {
+  const numChunks = Math.ceil(str.length / length);
+  const chunks = new Array(numChunks);
+
+  for (let i = 0; i < numChunks; i++) {
+    chunks[i] = str.slice(i * length, (i + 1) * length);
+  }
+
+  return chunks;
 }

--- a/.github/scripts/helpers/strings.js
+++ b/.github/scripts/helpers/strings.js
@@ -82,7 +82,7 @@ export function capitalizeFirstLetter(str) {
  */
 export function toTitleCase(str) {
   return splitWords(str)
-    .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
     .join(" ");
 }
 
@@ -114,7 +114,7 @@ export function toCamelCase(str) {
  */
 export function toPascalCase(str) {
   return splitWords(str)
-    .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
     .join("");
 }
 
@@ -129,7 +129,7 @@ export function toPascalCase(str) {
  */
 export function toKebabCase(str) {
   return splitWords(str)
-    .map(word => word.toLowerCase())
+    .map((word) => word.toLowerCase())
     .join("-");
 }
 
@@ -144,7 +144,7 @@ export function toKebabCase(str) {
  */
 export function toSnakeCase(str) {
   return splitWords(str)
-    .map(word => word.toLowerCase())
+    .map((word) => word.toLowerCase())
     .join("_");
 }
 
@@ -159,7 +159,7 @@ export function toSnakeCase(str) {
  */
 export function toUpperSnakeCase(str) {
   return splitWords(str)
-    .map(word => word.toUpperCase())
+    .map((word) => word.toUpperCase())
     .join("_");
 }
 
@@ -174,6 +174,6 @@ export function toUpperSnakeCase(str) {
  */
 export function toPascalSnakeCase(str) {
   return splitWords(str)
-    .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
     .join("_");
 }

--- a/.github/scripts/locales-cli-editor/main.js
+++ b/.github/scripts/locales-cli-editor/main.js
@@ -10,10 +10,10 @@
  * Usage: `node ./.github/scripts/locales-cli-editor/main.js`
  */
 
-import { input, select } from "@inquirer/prompts";
-import chalk from "chalk";
 import fs from "node:fs";
 import path, { resolve } from "node:path";
+import { input, select } from "@inquirer/prompts";
+import chalk from "chalk";
 
 //#region Constants
 
@@ -30,12 +30,12 @@ const LOCALES_PATH = path.join(LOCALES_DIR, LANG_CODE);
  */
 const SUPPORTED_LANGS = fs
   .readdirSync(LOCALES_DIR)
-  .filter(f => f !== "en" && fs.statSync(path.join(LOCALES_DIR, f)).isDirectory());
+  .filter((f) => f !== "en" && fs.statSync(path.join(LOCALES_DIR, f)).isDirectory());
 /**
  * The list of JSON files that can be edited
  * @type {readonly string[]}
  */
-const LOCALES_FILES = fs.readdirSync(LOCALES_PATH).filter(f => f.endsWith(".json"));
+const LOCALES_FILES = fs.readdirSync(LOCALES_PATH).filter((f) => f.endsWith(".json"));
 /**
  * The version of this script
  * @type {string}
@@ -87,7 +87,7 @@ function getKeyValue(filePath, key) {
     if (val && typeof val === "object" && part in val) {
       val = val[part];
     } else {
-      return undefined;
+      return;
     }
   }
   return typeof val === "string" ? val : undefined;
@@ -106,7 +106,9 @@ function setKeyValue(filePath, key, value) {
   let obj = data;
   for (let i = 0; i < parts.length - 1; i++) {
     obj = obj[parts[i]];
-    if (!obj) return false;
+    if (!obj) {
+      return false;
+    }
   }
   obj[parts[parts.length - 1]] = value;
   fs.writeFileSync(filePath, JSON.stringify(data, null, 2) + "\n", "utf8");
@@ -125,7 +127,9 @@ function deleteKey(filePath, key) {
   let obj = data;
   for (let i = 0; i < parts.length - 1; i++) {
     obj = obj[parts[i]];
-    if (!obj) return false;
+    if (!obj) {
+      return false;
+    }
   }
   delete obj[parts[parts.length - 1]];
   fs.writeFileSync(filePath, JSON.stringify(data, null, 2) + "\n", "utf8");
@@ -142,7 +146,7 @@ function deleteKey(filePath, key) {
  * @returns The string with special characters escaped
  */
 function escapeSpecialChars(str) {
-  return str.replace(/[\n\r\t]/g, c => {
+  return str.replace(/[\n\r\t]/g, (c) => {
     switch (c) {
       case "\n":
         return "\\n";
@@ -163,6 +167,7 @@ function escapeSpecialChars(str) {
  * @return The unescaped and postprocessed string
  */
 function unescapeSpecialCharsAndConvertQuotes(str) {
+  // biome-ignore format: the extra parentheses are unnecessary
   return str
     .replace(/(?<!\s)'(?=\S)/g, "’")
     // Replace double quotes that appear after a space (or the beginning of the string) with special left quote
@@ -170,7 +175,7 @@ function unescapeSpecialCharsAndConvertQuotes(str) {
     // Replace double quotes that appear after a non-space and are not followed by a non-dot with special right quote
     .replace(/(?<=\S)"/g, "”")
     // Unescape special escaped characters
-    .replace(/\\[nrt]/g, c => {
+    .replace(/\\[nrt]/g, (c) => {
       switch (c) {
         case "\\n":
           return "\n";
@@ -194,13 +199,12 @@ function unescapeSpecialCharsAndConvertQuotes(str) {
  */
 async function reword(fileChoice, keyChoice, keyValue) {
   const value = chalk.red(escapeSpecialChars(keyValue));
-  let newValue = unescapeSpecialCharsAndConvertQuotes(
+  const newValue = unescapeSpecialCharsAndConvertQuotes(
     await input({
       message: `"${keyChoice} current reads:\n\t${value}\nEnter new value for "${keyChoice}" (press TAB to edit the placeholder):\n`,
       default: keyValue,
-    })
-  )
-
+    }),
+  );
 
   if (newValue.trim().length === 0) {
     console.error(chalk.red.bold("✗  New value cannot be empty."));
@@ -258,7 +262,9 @@ async function main() {
     const allKeys = getAllKeysFromFile(filePath);
 
     if (allKeys.length === 0) {
-      console.error(chalk.red.bold("✗ Error: No keys found in file. This can happen if the file contains only nested objects."));
+      console.error(
+        chalk.red.bold("✗ Error: No keys found in file. This can happen if the file contains only nested objects."),
+      );
       return;
     }
 

--- a/.github/scripts/locales-cli-editor/main.js
+++ b/.github/scripts/locales-cli-editor/main.js
@@ -10,46 +10,43 @@
  * Usage: `node ./.github/scripts/locales-cli-editor/main.js`
  */
 
-import fs from "node:fs";
-import path, { resolve } from "node:path";
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
 import { input, select } from "@inquirer/prompts";
 import chalk from "chalk";
 
 //#region Constants
 
-const __dirname = import.meta.dirname;
 /** The path to the root of the locales directory */
-const LOCALES_DIR = resolve(__dirname, "../../../");
+const LOCALES_DIR = resolve(import.meta.dirname, "../../../");
 /** The language code to edit */
 const LANG_CODE = "en";
 /** The path to the English locales folder */
-const LOCALES_PATH = path.join(LOCALES_DIR, LANG_CODE);
+const LOCALES_PATH = join(LOCALES_DIR, LANG_CODE);
 /**
  * The list of supported languages
  * @type {readonly string[]}
  */
-const SUPPORTED_LANGS = fs
-  .readdirSync(LOCALES_DIR)
-  .filter((f) => f !== "en" && fs.statSync(path.join(LOCALES_DIR, f)).isDirectory());
+const SUPPORTED_LANGS = readdirSync(LOCALES_DIR) //
+  .filter((f) => f !== "en" && statSync(join(LOCALES_DIR, f)).isDirectory());
 /**
  * The list of JSON files that can be edited
  * @type {readonly string[]}
  */
-const LOCALES_FILES = fs.readdirSync(LOCALES_PATH).filter((f) => f.endsWith(".json"));
+const LOCALES_FILES = readdirSync(LOCALES_PATH).filter((f) => f.endsWith(".json"));
 /**
  * The version of this script
  * @type {string}
  */
 const SCRIPT_VERSION = "1.0.0";
 
-//#endregion
+//#endregion Constants
 
 //#region Helpers
 
 /**
  * Get the flat list of keys in an object, skipping nested objects.
- * @param {object} obj
- * @param {string} prefix
+ * @param {object} obj - The object to get keys from
  * @returns {string[]} The list of keys in the object
  */
 function getFlatKeys(obj) {
@@ -64,23 +61,23 @@ function getFlatKeys(obj) {
 }
 
 /**
- * Return a list of all top-level keys in a locales file, skipping keys that hold nested objects
- * @param {string} filePath
+ * Return a list of all top-level keys in a locales file, skipping keys that hold nested objects.
+ * @param {string} filePath - The path to the locales file
  * @returns {string[]} The list of keys in the file
  */
 function getAllKeysFromFile(filePath) {
-  const data = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  const data = JSON.parse(readFileSync(filePath, "utf8"));
   return getFlatKeys(data);
 }
 
 /**
- * Get the value of a key from the provided locales file
- * @param {string} filePath The path to the locales file
- * @param {string} key The key to get the value of
- * @returns {string} The value of the key, or `undefined` if the key either does not exist or is not a string
+ * Get the value of a key from the provided locales file.
+ * @param {string} filePath - The path to the locales file
+ * @param {string} key - The key to get the value of
+ * @returns {string | undefined} The value of the key, or `undefined` if the key either does not exist or is not a string
  */
 function getKeyValue(filePath, key) {
-  const data = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  const data = JSON.parse(readFileSync(filePath, "utf8"));
   const parts = key.split(".");
   let val = data;
   for (const part of parts) {
@@ -95,13 +92,13 @@ function getKeyValue(filePath, key) {
 
 /**
  * Update the value of a key in a locales file.
- * @param {string} filePath The path to the locales file to edit
- * @param {string} key The name of the key to set
- * @param {string} value The value to set the key to
+ * @param {string} filePath - The path to the locales file to edit
+ * @param {string} key - The name of the key to set
+ * @param {string} value - The value to set the key to
  * @returns {boolean} Whether the key was set
  */
 function setKeyValue(filePath, key, value) {
-  const data = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  const data = JSON.parse(readFileSync(filePath, "utf8"));
   const parts = key.split(".");
   let obj = data;
   for (let i = 0; i < parts.length - 1; i++) {
@@ -110,19 +107,20 @@ function setKeyValue(filePath, key, value) {
       return false;
     }
   }
+  // biome-ignore lint/style/useAtIndex: can't use non-null assertions in js
   obj[parts[parts.length - 1]] = value;
-  fs.writeFileSync(filePath, JSON.stringify(data, null, 2) + "\n", "utf8");
+  writeFileSync(filePath, JSON.stringify(data, null, 2) + "\n", "utf8");
   return true;
 }
 
 /**
  * Delete a key from a locales file.
- * @param {string} filePath
- * @param {string} key
+ * @param {string} filePath - The path to the locales file
+ * @param {string} key - The key to delete
  * @returns {boolean} Whether a matching key was found and deleted
  */
 function deleteKey(filePath, key) {
-  const data = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  const data = JSON.parse(readFileSync(filePath, "utf8"));
   const parts = key.split(".");
   let obj = data;
   for (let i = 0; i < parts.length - 1; i++) {
@@ -131,18 +129,19 @@ function deleteKey(filePath, key) {
       return false;
     }
   }
+  // biome-ignore lint/style/useAtIndex: can't use non-null assertions in js
   delete obj[parts[parts.length - 1]];
-  fs.writeFileSync(filePath, JSON.stringify(data, null, 2) + "\n", "utf8");
+  writeFileSync(filePath, JSON.stringify(data, null, 2) + "\n", "utf8");
   return true;
 }
 
-//#endregion
+//#endregion Helpers
 
 //#region Interactive CLI
 
 /**
- * Escape special chatacters in a string to display them literally in the CLI.
- * @param {string} str The string to escape
+ * Escape special characters in a string to display them literally in the CLI.
+ * @param {string} str - The string to escape
  * @returns The string with special characters escaped
  */
 function escapeSpecialChars(str) {
@@ -163,7 +162,7 @@ function escapeSpecialChars(str) {
 /**
  * Convert escaped special characters back to their original form and convert
  * normal quotes to the special quote characters.
- * @param {string} str The string to unescape and postprocess
+ * @param {string} str - The string to unescape and postprocess
  * @return The unescaped and postprocessed string
  */
 function unescapeSpecialCharsAndConvertQuotes(str) {
@@ -192,9 +191,9 @@ function unescapeSpecialCharsAndConvertQuotes(str) {
 /**
  * Handler for the "Reword" action - rewords the key in "en" and deletes it from
  * all other locale files.
- * @param {string} fileChoice The locales file to edit
- * @param {string} keyChoice The key to reword
- * @param {string} keyValue The current value of the key
+ * @param {string} fileChoice - The locales file to edit
+ * @param {string} keyChoice - The key to reword
+ * @param {string} keyValue - The current value of the key
  * @returns {Promise<void>}
  */
 async function reword(fileChoice, keyChoice, keyValue) {
@@ -212,31 +211,22 @@ async function reword(fileChoice, keyChoice, keyValue) {
     return;
   }
 
-  const enFilePath = path.join(LOCALES_DIR, "en", fileChoice);
+  const enFilePath = join(LOCALES_DIR, "en", fileChoice);
   setKeyValue(enFilePath, keyChoice, newValue);
 
-  for (const lang of SUPPORTED_LANGS) {
-    const langFilePath = path.join(LOCALES_DIR, lang, fileChoice);
-    if (fs.existsSync(langFilePath)) {
-      deleteKey(langFilePath, keyChoice, newValue);
-    }
-  }
+  deleteNonEnglishKeys(fileChoice, keyChoice);
   console.log(chalk.green(`✔ Key "${keyChoice}" reworded in "en" and removed from all other files.`));
 }
 
 /**
- * Handler for when the user chooses the "Delete" action
- *
- * @remarks
- * Deletes the key from all locale files.
- * @param {string} fileChoice The locales file to edit
- * @param {string} keyChoice The key to delete
- * @returns {Promise<void>}
+ * Deletes a key from all non-English locale files.
+ * @param {string} fileChoice - The locales file to edit
+ * @param {string} keyChoice - The key to delete
  */
-async function doDelete(fileChoice, keyChoice) {
+function deleteNonEnglishKeys(fileChoice, keyChoice) {
   for (const lang of SUPPORTED_LANGS) {
-    const langFilePath = path.join(LOCALES_DIR, lang, fileChoice);
-    if (fs.existsSync(langFilePath)) {
+    const langFilePath = join(LOCALES_DIR, lang, fileChoice);
+    if (existsSync(langFilePath)) {
       deleteKey(langFilePath, keyChoice);
     }
   }
@@ -258,7 +248,7 @@ async function main() {
       choices: LOCALES_FILES,
     });
 
-    const filePath = path.join(LOCALES_PATH, fileChoice);
+    const filePath = join(LOCALES_PATH, fileChoice);
     const allKeys = getAllKeysFromFile(filePath);
 
     if (allKeys.length === 0) {
@@ -276,7 +266,7 @@ async function main() {
 
     let keyValue = getKeyValue(filePath, keyChoice);
     if (keyValue === undefined) {
-      console.error(chalk.red.bold(`✗ Error: Editing non-string keys (${keyChoice}) is not yet supported!.`));
+      console.error(chalk.red.bold(`✗ Error: Editing non-string keys (${keyChoice}) is not yet supported!`));
       return;
     }
     keyValue = escapeSpecialChars(keyValue);
@@ -293,7 +283,7 @@ async function main() {
         await reword(fileChoice, keyChoice, keyValue);
         break;
       case "Delete":
-        await doDelete(fileChoice, keyChoice);
+        deleteNonEnglishKeys(fileChoice, keyChoice);
         break;
       case "Cancel":
         console.log(chalk.yellow("Operation cancelled."));
@@ -308,4 +298,4 @@ async function main() {
 
 await main();
 
-//#endregion
+//#endregion Interactive CLI

--- a/.github/scripts/locales-format-checker/check-locales.js
+++ b/.github/scripts/locales-format-checker/check-locales.js
@@ -20,7 +20,7 @@ import { getFiles, getKeys, getMainLanguageKeys, removeLanguageCode } from "./ge
  * @returns {Promise<incorrectKeys>} The incorrect keys found.
  */
 export async function checkLocaleKeys(options) {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     /** @type {incorrectKeys} */
     let incorrectKeys = {};
 
@@ -68,7 +68,7 @@ function checkForIncorrectKeys(filePath, options) {
     printVerboseLog(`${COLORS.info}No keys found in ${filePath}`, options);
     return null;
   }
-  const entries = keys.map((key, index) => analyzeKey(key, index, options)).filter(e => e !== null);
+  const entries = keys.map((key, index) => analyzeKey(key, index, options)).filter((e) => e !== null);
 
   if (entries.length > 0) {
     incorrectKeys[filePath] = entries;
@@ -132,7 +132,7 @@ function processExtensions(key) {
  * @returns {Promise<incorrectFileNames>} The incorrect file names found.
  */
 export async function checkLocaleFileNames(options) {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     /** @type {incorrectFileNames} */
     const incorrectFileNames = {};
 
@@ -201,7 +201,7 @@ function checkForIncorrectFileName(filePath, options) {
  * @returns {Promise<fileKeys>} The incorrect file names found.
  */
 export async function checkLocaleMissingKeys(options) {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     /** @type {fileKeys} */
     const missingKeys = {};
 

--- a/.github/scripts/locales-format-checker/check-locales.js
+++ b/.github/scripts/locales-format-checker/check-locales.js
@@ -1,4 +1,4 @@
-import * as core from "@actions/core";
+import { endGroup } from "@actions/core";
 import {
   toCamelCase,
   toKebabCase,
@@ -9,63 +9,63 @@ import {
 } from "../helpers/strings.js";
 import { COLORS, fileNameFormat, i18nextKeyExtensions, keyFormat, LOCALES_DIR, mainLanguage } from "./constants.js";
 import { getFiles, getKeys, getMainLanguageKeys, removeLanguageCode } from "./get-files.js";
+import { failed, logInfo, logStartGroup } from "./utils.js";
 
-/** @import * from "./types" */
+/** @import { FileKeys, Format, IncorrectFileName, IncorrectFileNames, IncorrectKey, IncorrectKeys, Options } from "./types.js" */
 
-//#region Key Format
+// #region Key Format
 
 /**
  * Check the key format of all locales files.
- * @param {options} options - The command line options.
- * @returns {Promise<incorrectKeys>} The incorrect keys found.
+ * @param {Options} options - The command line options
+ * @returns {IncorrectKeys} The incorrect keys found.
  */
-export async function checkLocaleKeys(options) {
-  return new Promise((resolve) => {
-    /** @type {incorrectKeys} */
-    let incorrectKeys = {};
+export function checkLocaleKeys(options) {
+  /** @type {IncorrectKeys} */
+  let incorrectKeys = {};
 
-    for (const languageCode of options.languages) {
-      if (options.verbose) {
-        core.startGroup(`${COLORS.info}Checking keys for "${languageCode}"`);
-      } else {
-        core.info(`${COLORS.info}Checking keys for "${languageCode}"`);
+  for (const languageCode of options.languages) {
+    const logFunc = options.verbose ? logStartGroup : logInfo;
+    logFunc(COLORS.info, `Checking keys for "${languageCode}"`);
+
+    const path = `${LOCALES_DIR}/${languageCode}`;
+    const files = getFiles(path);
+    let languageCodeIncorrectKeys = 0;
+
+    for (const filePath of files) {
+      const fileIncorrectKeys = checkForIncorrectKeys(filePath, options);
+      if (fileIncorrectKeys !== null) {
+        incorrectKeys = { ...incorrectKeys, ...fileIncorrectKeys };
+        languageCodeIncorrectKeys += Object.values(fileIncorrectKeys).reduce((sum, val) => sum + val.length, 0);
       }
-      const path = `${LOCALES_DIR}/${languageCode}`;
-      const files = getFiles(path);
-      let languageCodeIncorrectKeys = 0;
-      for (const filePath of files) {
-        const fileIncorrectKeys = checkForIncorrectKeys(filePath, options);
-        if (fileIncorrectKeys !== null) {
-          incorrectKeys = { ...incorrectKeys, ...fileIncorrectKeys };
-          languageCodeIncorrectKeys += Object.values(fileIncorrectKeys).reduce((sum, val) => sum + val.length, 0);
-        }
-      }
-      if (options.verbose) {
-        core.endGroup();
-      }
-      core.info(
-        `${COLORS.magenta}Checked ${files.length} files for language "${languageCode}" and found ${languageCodeIncorrectKeys} incorrect keys.\n`,
-      );
     }
-    resolve(incorrectKeys);
-  });
+
+    if (options.verbose) {
+      endGroup();
+    }
+    logInfo(
+      COLORS.magenta,
+      `Checked ${files.length} files for language "${languageCode}" and found ${languageCodeIncorrectKeys} incorrect keys.\n`,
+    );
+  }
+
+  return incorrectKeys;
 }
 
 /**
  * Check a file for incorrect keys.
- * @param {string} filePath - The path to the file to check.
- * @param {options} options - The command line options.
- * @returns {incorrectKeys | null} The incorrect keys found in the file.
+ * @param {string} filePath - The path to the file to check
+ * @param {Options} options - The command line options
+ * @returns {IncorrectKeys | null} The incorrect keys found in the file.
  */
 function checkForIncorrectKeys(filePath, options) {
-  /** @type {incorrectKeys} */
+  /** @type {IncorrectKeys} */
   const incorrectKeys = {};
-  printVerboseLog(`${COLORS.file}checking file: ${filePath}`, options);
+  printVerboseLog(COLORS.file, `checking file: ${filePath}`, options);
 
-  /** @type {object | null} */
   const keys = getKeys(filePath);
   if (keys === null) {
-    printVerboseLog(`${COLORS.info}No keys found in ${filePath}`, options);
+    printVerboseLog(COLORS.info, `No keys found in ${filePath}`, options);
     return null;
   }
   const entries = keys.map((key, index) => analyzeKey(key, index, options)).filter((e) => e !== null);
@@ -75,19 +75,19 @@ function checkForIncorrectKeys(filePath, options) {
   }
 
   if (entries.length === 0) {
-    printVerboseLog(`${COLORS.green}No incorrect keys found in ${filePath}`, options);
+    printVerboseLog(COLORS.green, `No incorrect keys found in ${filePath}`, options);
   } else {
-    printVerboseLog(`${COLORS.red}Found ${entries.length} incorrect keys in ${filePath}`, options);
+    printVerboseLog(COLORS.red, `Found ${entries.length} incorrect keys in ${filePath}`, options);
   }
   return incorrectKeys;
 }
 
 /**
  * Analyze a key for correctness.
- * @param {string} key - The key to analyze.
- * @param {number} index - The index of the key.
- * @param {options} options - The command line options.
- * @returns {incorrectKey | null} The incorrect key and its correction or null if the key is correct.
+ * @param {string} key - The key to analyze
+ * @param {number} index - The index of the key
+ * @param {Options} options - The command line options
+ * @returns {IncorrectKey | null} The incorrect key and its correction or null if the key is correct.
  */
 function analyzeKey(key, index, options) {
   const line = index + 2;
@@ -98,14 +98,15 @@ function analyzeKey(key, index, options) {
   if (correctKey === key) {
     return null;
   }
-  printVerboseLog(`${COLORS.red}Incorrect key found at line ${line}: ${key}`, options);
-  printVerboseLog(`${COLORS.corrected}Correct key: ${correctKey}`, options);
+
+  printVerboseLog(COLORS.red, `Incorrect key found at line ${line}: ${key}`, options);
+  printVerboseLog(COLORS.corrected, `Correct key: ${correctKey}`, options);
   return { incorrectKey: key, correctedKey: correctKey, line };
 }
 
 /**
  * Process i18next key extensions.
- * @param {string} key - The key to process.
+ * @param {string} key - The key to process
  * @returns {string} The correct processed key.
  */
 function processExtensions(key) {
@@ -122,63 +123,63 @@ function processExtensions(key) {
   return ret;
 }
 
-//#endregion
+// #endregion Key Format
 
-//#region File Name Format
+// #region File Name Format
 
 /**
  * Check the file name format of all locales files.
- * @param {options} options - The command line options.
- * @returns {Promise<incorrectFileNames>} The incorrect file names found.
+ * @param {Options} options - The command line options
+ * @returns {IncorrectFileNames} The incorrect file names found.
  */
-export async function checkLocaleFileNames(options) {
-  return new Promise((resolve) => {
-    /** @type {incorrectFileNames} */
-    const incorrectFileNames = {};
+export function checkLocaleFileNames(options) {
+  /** @type {IncorrectFileNames} */
+  const incorrectFileNames = {};
 
-    for (const languageCode of options.languages) {
-      if (options.verbose) {
-        core.startGroup(`${COLORS.info}Checking file names for "${languageCode}"`);
-      } else {
-        core.info(`${COLORS.info}Checking file names for "${languageCode}"`);
+  for (const languageCode of options.languages) {
+    const logFunc = options.verbose ? logStartGroup : logInfo;
+    logFunc(COLORS.info, `Checking file names for "${languageCode}"`);
+
+    const path = `${LOCALES_DIR}/${languageCode}`;
+    const files = getFiles(path);
+    let languageCodeIncorrectFiles = 0;
+    const InvalidFileNamesForLang = [];
+
+    for (const filePath of files) {
+      const fileNameResult = checkForIncorrectFileName(filePath, options);
+      if (fileNameResult !== null) {
+        InvalidFileNamesForLang.push(fileNameResult);
+        languageCodeIncorrectFiles++;
       }
-      const path = `${LOCALES_DIR}/${languageCode}`;
-      const files = getFiles(path);
-      let languageCodeIncorrectFiles = 0;
-      const InvalidFileNamesForLang = [];
-      for (const filePath of files) {
-        const fileNameResult = checkForIncorrectFileName(filePath, options);
-        if (fileNameResult !== null) {
-          InvalidFileNamesForLang.push(fileNameResult);
-          languageCodeIncorrectFiles++;
-        }
-      }
-      if (languageCodeIncorrectFiles > 0) {
-        incorrectFileNames[languageCode] = InvalidFileNamesForLang;
-      }
-      if (options.verbose) {
-        core.endGroup();
-      }
-      core.info(
-        `${COLORS.magenta}Checked ${files.length} files for language "${languageCode}" and found ${languageCodeIncorrectFiles} incorrect file names.\n`,
-      );
     }
-    resolve(incorrectFileNames);
-  });
+    if (languageCodeIncorrectFiles > 0) {
+      incorrectFileNames[languageCode] = InvalidFileNamesForLang;
+    }
+
+    if (options.verbose) {
+      endGroup();
+    }
+    logInfo(
+      COLORS.magenta,
+      `Checked ${files.length} files for language "${languageCode}" and found ${languageCodeIncorrectFiles} incorrect file names.\n`,
+    );
+  }
+
+  return incorrectFileNames;
 }
 
 /**
  * Check a file name for incorrect format.
- * @param {string} filePath - The path to the file to check.
- * @param {options} options - The command line options.
- * @returns {incorrectFileName | null} The incorrect file name found.
+ * @param {string} filePath - The path to the file to check
+ * @param {Options} options - The command line options
+ * @returns {IncorrectFileName | null} The incorrect file name found.
  */
 function checkForIncorrectFileName(filePath, options) {
-  printVerboseLog(`${COLORS.file}checking file: ${filePath}`, options);
+  printVerboseLog(COLORS.file, `checking file: ${filePath}`, options);
 
   const fileName = filePath.split("/").pop();
   if (fileName === undefined) {
-    printVerboseLog(`${COLORS.red}No file found at path: ${filePath}`, options);
+    printVerboseLog(COLORS.red, `No file found at path: ${filePath}`, options);
     return null;
   }
 
@@ -186,65 +187,66 @@ function checkForIncorrectFileName(filePath, options) {
   if (correctFileName === fileName) {
     return null;
   }
-  printVerboseLog(`${COLORS.red}Incorrect file name found: ${fileName}`, options);
-  printVerboseLog(`${COLORS.corrected}Correct file name: ${correctFileName}`, options);
+
+  printVerboseLog(COLORS.red, `Incorrect file name found: ${fileName}`, options);
+  printVerboseLog(COLORS.corrected, `Correct file name: ${correctFileName}`, options);
   return { incorrectFileName: fileName, correctedFileName: correctFileName };
 }
 
-//#endregion
+// #endregion File Name Format
 
-//#region Missing Keys
+// #region Missing Keys
 
 /**
  * Check the file name format of all locales files.
- * @param {options} options - The command line options.
- * @returns {Promise<fileKeys>} The incorrect file names found.
+ * @param {Options} options - The command line options
+ * @returns {FileKeys} The incorrect file names found.
  */
-export async function checkLocaleMissingKeys(options) {
-  return new Promise((resolve) => {
-    /** @type {fileKeys} */
-    const missingKeys = {};
+export function checkLocaleMissingKeys(options) {
+  /** @type {FileKeys} */
+  const missingKeys = {};
 
-    for (const languageCode of options.languages) {
-      if (languageCode === mainLanguage) {
-        continue;
-      }
-      if (options.verbose) {
-        core.startGroup(`${COLORS.info}Checking missing keys for "${languageCode}"`);
-      } else {
-        core.info(`${COLORS.info}Checking missing keys for "${languageCode}"`);
-      }
-      const path = `${LOCALES_DIR}/${languageCode}`;
-      const files = getFiles(path);
-      let languageCodeMissingKeys = 0;
-      for (const filePath of files) {
-        const fileMissingKeys = checkForMissingKeys(filePath, options);
-        if (fileMissingKeys !== null && fileMissingKeys.length > 0) {
-          missingKeys[filePath] = fileMissingKeys;
-          languageCodeMissingKeys += fileMissingKeys.length;
-        }
-      }
-      if (options.verbose) {
-        core.endGroup();
-      }
-      core.info(
-        `${COLORS.magenta}Checked ${files.length} files for language "${languageCode}" and found ${languageCodeMissingKeys} incorrect keys.`,
-      );
+  for (const languageCode of options.languages) {
+    if (languageCode === mainLanguage) {
+      continue;
     }
 
-    resolve(missingKeys);
-  });
+    const logFunc = options.verbose ? logStartGroup : logInfo;
+    logFunc(COLORS.info, `Checking missing keys for "${languageCode}"`);
+
+    const path = `${LOCALES_DIR}/${languageCode}`;
+    const files = getFiles(path);
+    let languageCodeMissingKeys = 0;
+
+    for (const filePath of files) {
+      const fileMissingKeys = checkForMissingKeys(filePath, options);
+      if (fileMissingKeys !== null && fileMissingKeys.length > 0) {
+        missingKeys[filePath] = fileMissingKeys;
+        languageCodeMissingKeys += fileMissingKeys.length;
+      }
+    }
+
+    if (options.verbose) {
+      endGroup();
+    }
+    logInfo(
+      COLORS.magenta,
+      `Checked ${files.length} files for language "${languageCode}" and found ${languageCodeMissingKeys} incorrect keys.`,
+    );
+  }
+
+  return missingKeys;
 }
 
 /** Check for keys, that don't exist in the main language
- * @param {string} filePath - The path to the file to check.
- * @param {options} options - The command line options.
+ * @param {string} filePath - The path to the file to check
+ * @param {Options} options - The command line options
  * @returns {string[] | null} the keys, that don't exist in the main language
  */
 function checkForMissingKeys(filePath, options) {
   /** @type {string[]} */
   const missingKeys = [];
-  printVerboseLog(`${COLORS.file}checking file: ${filePath}`, options);
+  printVerboseLog(COLORS.file, `checking file: ${filePath}`, options);
 
   const keys = getKeys(filePath);
   if (keys === null) {
@@ -257,22 +259,22 @@ function checkForMissingKeys(filePath, options) {
     if (!keyExists) {
       missingKeys.push(key);
 
-      printVerboseLog(`${COLORS.red}Missing key found: ${key}`, options);
+      printVerboseLog(COLORS.red, `Missing key found: ${key}`, options);
     }
   }
 
   if (missingKeys.length > 0 && options.verbose) {
-    core.info(`${COLORS.red}Found ${missingKeys.length} missing keys in ${filePath}`);
+    logInfo(COLORS.red, `Found ${missingKeys.length} missing keys in ${filePath}`);
   }
   return missingKeys;
 }
 
-//#endregion
+// #endregion Missing Keys
 
 /**
  * Returns the correct format for the provided format.
- * @param {string} key - The key to get the correct format for.
- * @param {format} format - The format to get the correct format for.
+ * @param {string} key - The key to get the correct format for
+ * @param {Format} format - The format to get the correct format for
  * @returns {string} The correct format.
  */
 function getCorrectFormat(key, format) {
@@ -290,17 +292,19 @@ function getCorrectFormat(key, format) {
     case "Pascal_Snake_Case":
       return toPascalSnakeCase(key);
     default:
-      core.setFailed(`Unknown format: "${format}"`);
+      failed(`Unknown format: "${format}"`);
+      return "";
   }
 }
 
 /**
  * Prints a console log if verbose logging is enabled
+ * @param {string} color - The color to apply to the message
  * @param {string} text - The text to print to the console
- * @param {options} options - The command line options.
+ * @param {Options} options - The command line options
  */
-function printVerboseLog(text, options) {
+function printVerboseLog(color, text, options) {
   if (options.verbose) {
-    core.info(text);
+    logInfo(color, text);
   }
 }

--- a/.github/scripts/locales-format-checker/constants.js
+++ b/.github/scripts/locales-format-checker/constants.js
@@ -1,13 +1,13 @@
-/**
- * The directory containing all locales files.
- */
+/** @import { Format } from "./types.js" */
+
+/** The directory containing all locales files. */
 export const LOCALES_DIR = ".";
 
-/**
- * A list of files to ignore.
- */
+/** A list of files to ignore. */
 export const ignoreList = [
   "package.json",
+  "biome.jsonc",
+  "tsconfig.json",
   "modifier-type.json", // todo: remove after modifier rework
   "modifier.json",
   "modifier-select-ui-handler.json",
@@ -23,7 +23,7 @@ export const ignoreList = [
 ];
 
 /**
- * A list of inbuild i18next key extensions which use snake_case instead of camelCase.
+ * A list of built-in i18next key extensions which use snake_case instead of camelCase.
  * @example `AceTrainer_male`
  * @see {@link https://www.i18next.com/translation-function/context}
  */
@@ -31,30 +31,23 @@ export const i18nextKeyExtensions = ["_male", "_female", "_ordinal", "_one", "_t
 
 /**
  * The key format to check for.
- * @type {format}
+ * @type {Format}
  */
 export const keyFormat = "camelCase";
 
 /**
  * The file name format to check for.
- * @type {format}
+ * @type {Format}
  */
 export const fileNameFormat = "kebab-case";
 
-/**
- * The file extension to check.
- */
+/** The file extension to check. */
 export const fileExtension = ".json";
 
-/**
- * The main language code.
- * Used to check if the key exists in the main language.
- */
+/** The main language code. Used to check if the key exists in the main language. */
 export const mainLanguage = "en";
 
-/**
- * 24 bit Color map
- */
+/** 24 bit Color map of ANSI color codes */
 export const COLORS = {
   blue: "\u001b[38;2;0;0;255m",
   green: "\u001b[38;2;0;255;0m",
@@ -63,4 +56,6 @@ export const COLORS = {
   info: "\u001b[38;2;255;165;0m",
   file: "\u001b[38;2;128;128;128m",
   corrected: "\u001b[38;2;0;150;255m",
+  "orange-red": "\u001b[38;2;255;127;80m",
+  reset: "\u001b[0m",
 };

--- a/.github/scripts/locales-format-checker/get-files.js
+++ b/.github/scripts/locales-format-checker/get-files.js
@@ -1,11 +1,13 @@
 import { existsSync, lstatSync, readdirSync, readFileSync } from "node:fs";
 import { format } from "node:util";
-import * as core from "@actions/core";
 import { fileExtension, ignoreList, LOCALES_DIR, mainLanguage } from "./constants.js";
+import { failed } from "./utils.js";
+
+/** @import { FileKeys } from "./types.js" */
 
 /**
  * Gets all files in a directory and subdirectories.
- * @param {string} dir
+ * @param {string} dir - The directory to process
  * @returns {string[]} A list of all files in the directory and subdirectories.
  */
 export function getFiles(dir) {
@@ -34,10 +36,7 @@ export function getFiles(dir) {
  * @returns {string[]} A list of all language codes.
  */
 export function getLanguageCodes() {
-  /**
-   * A list of all language codes in the locales folder.
-   * @type {string[]}
-   */
+  /** @type {string[]} */
   const languageCodes = [];
 
   if (existsSync(LOCALES_DIR)) {
@@ -51,7 +50,7 @@ export function getLanguageCodes() {
     }
   } else {
     const errStr = format("Locales folder not found: %s", LOCALES_DIR);
-    core.setFailed(errStr);
+    failed(errStr);
     process.exit();
   }
 
@@ -60,7 +59,7 @@ export function getLanguageCodes() {
 
 /**
  * Get the keys of a json file.
- * @param {string} filePath - The path to the file to read.
+ * @param {string} filePath - The path to the file to read
  * @returns {string[] | null} The keys for the file.
  */
 export function getKeys(filePath) {
@@ -74,14 +73,16 @@ export function getKeys(filePath) {
     const ret = keys.length > 0 ? keys : null;
     return ret;
   } catch (error) {
-    core.setFailed(`Error parsing ${filePath}: ${error.message}`);
+    failed(`Error parsing ${filePath}: ${error.message}`);
     return null;
   }
 }
 
-/** Get the keys from an json object.
+/**
+ * Get the keys from a JSON object.
+ *
  * This function is used by {@linkcode getKeys} to get nested keys.
- * @param {object} data - The json object to get the keys from.
+ * @param {object} data - The json object to get the keys from
  * @returns {string[]} The keys of the object, including nested keys.
  */
 function getKeysByData(data) {
@@ -98,12 +99,10 @@ function getKeysByData(data) {
   return keys;
 }
 
-/**
- * @returns {fileKeys} The keys per file for the main language.
- */
+/** @returns {FileKeys} The keys per file for the main language. */
 export function getMainLanguageKeys() {
   const files = getFiles(mainLanguage);
-  /** @type {fileKeys} */
+  /** @type {FileKeys} */
   const mainLanguageKeys = {};
 
   for (const filePath of files) {
@@ -118,8 +117,9 @@ export function getMainLanguageKeys() {
   return mainLanguageKeys;
 }
 
-/** Removes the language code from a file path.
- * @param {string} filePath - The file path to process.
+/**
+ * Removes the language code from a file path.
+ * @param {string} filePath - The file path to process
  * @returns {string} The file path without the language code.
  */
 export function removeLanguageCode(filePath) {

--- a/.github/scripts/locales-format-checker/main.js
+++ b/.github/scripts/locales-format-checker/main.js
@@ -1,7 +1,8 @@
-import * as core from "@actions/core";
+import { endGroup } from "@actions/core";
 import { checkLocaleFileNames, checkLocaleKeys, checkLocaleMissingKeys } from "./check-locales.js";
 import { COLORS, mainLanguage } from "./constants.js";
 import { getLanguageCodes } from "./get-files.js";
+import { failed, logInfo, logStartGroup } from "./utils.js";
 
 /**
  * @packageDocumentation
@@ -11,38 +12,40 @@ import { getLanguageCodes } from "./get-files.js";
  * If no languages are provided, it will check all languages.
  */
 
+/** @import { FileKeys, IncorrectFileName, IncorrectFileNames, IncorrectKeys, Options } from "./types.js" */
+
 const version = "1.0.0";
 
 async function main() {
-  core.info(`\u001b[38;2;255;127;80m🍳 Locales format checker v${version}`);
+  logInfo(COLORS["orange-red"], `🍳 Locales format checker v${version}`);
 
   try {
     const args = process.argv.slice(2);
     const options = parseArgs(args);
 
     if (!options.checkKeys && !options.checkFileNames && !options.checkMissing) {
-      core.setFailed("✗ Error: No options provided!");
+      failed("✗ Error: No options provided!");
       return;
     }
 
-    /** @type {incorrectKeys} */
+    /** @type {IncorrectKeys} */
     let keyOutput = {};
-    /** @type {incorrectFileNames} */
+    /** @type {IncorrectFileNames} */
     let fileNameOutput = {};
-    /** @type {fileKeys} */
+    /** @type {FileKeys} */
     let mainLanguageMissingKeys = {};
 
     if (options.checkKeys) {
-      core.info(`${COLORS.info}Checking key format...`);
-      keyOutput = await checkLocaleKeys(options);
+      logInfo(COLORS.info, "Checking key format...");
+      keyOutput = checkLocaleKeys(options);
     }
     if (options.checkFileNames) {
-      core.info(`${COLORS.info}Checking file name format...`);
-      fileNameOutput = await checkLocaleFileNames(options);
+      logInfo(COLORS.info, "Checking file name format...");
+      fileNameOutput = checkLocaleFileNames(options);
     }
     if (options.checkMissing) {
-      core.info(`${COLORS.info}Checking for missing keys...`);
-      mainLanguageMissingKeys = await checkLocaleMissingKeys(options);
+      logInfo(COLORS.info, "Checking for missing keys...");
+      mainLanguageMissingKeys = checkLocaleMissingKeys(options);
     }
 
     if (options.checkKeys) {
@@ -57,19 +60,19 @@ async function main() {
       displayMissingResult(mainLanguageMissingKeys, options);
     }
   } catch (error) {
-    core.setFailed(error.message);
+    failed(error.message);
   }
 }
 
 /**
  * Parse the command line arguments.
  * @param {string[]} args - The command line arguments
- * @returns {options}
+ * @returns {Options}
  */
 function parseArgs(args) {
   const optionArgs = args.filter((arg) => arg.startsWith("-"));
   const languageArgs = args.filter((arg) => !arg.startsWith("-"));
-  /** @type {options} */
+  /** @type {Options} */
   const options = {
     checkKeys: false,
     checkFileNames: false,
@@ -97,8 +100,8 @@ function parseArgs(args) {
         options.verbose = true;
         break;
       default:
-        core.setFailed(`Unknown option: ${arg}`);
-        showHelpText();
+        failed(`Unknown option: ${arg}`);
+        // showHelpText(); // <-- this function doesn't exist
         process.exit();
     }
   }
@@ -106,7 +109,7 @@ function parseArgs(args) {
   const validLanguages = getLanguageCodes();
   for (const language of languageArgs) {
     if (!validLanguages.includes(language)) {
-      core.setFailed(`Invalid language: ${language}`);
+      failed(`Invalid language: ${language}`);
       process.exit();
     }
     options.languages.push(language);
@@ -120,41 +123,41 @@ function parseArgs(args) {
 
 /**
  * Display the results for the key format check.
- * @param {incorrectKeys} result - The incorrect keys found.
- * @param {options} options - The options used.
+ * @param {IncorrectKeys} result - The incorrect keys found.
+ * @param {Options} options - The options used.
  */
 function displayKeyResults(result, options) {
-  core.info(`${COLORS.info}Key Result:`);
+  logInfo(COLORS.info, "Key Result:");
   if (Object.keys(result).length > 0) {
-    core.setFailed("Found incorrect keys");
+    failed("Found incorrect keys");
     // Log incorrect keys per language
     for (const languageCode of options.languages) {
       const incorrectKeysForLang = Object.entries(result).filter(([path]) => path.includes(`/${languageCode}/`));
       const incorrectKeysCount = incorrectKeysForLang.reduce((sum, [_, val]) => sum + val.length, 0);
       const color = incorrectKeysCount > 0 ? COLORS.red : COLORS.green;
-      core.startGroup(`${color}Result for ${languageCode}`);
-      core.info(`${color}${languageCode}: ${incorrectKeysCount} incorrect keys`);
+      logStartGroup(color, `Result for ${languageCode}`);
+      logInfo(color, `${languageCode}: ${incorrectKeysCount} incorrect keys`);
       // log all incorrect keys for the language
       displayIncorrectKeys(languageCode, Object.fromEntries(incorrectKeysForLang));
-      core.endGroup();
+      endGroup();
     }
     const incorrectKeyCount = Object.values(result).reduce((sum, val) => sum + val.length, 0);
-    core.setFailed(`✗ Found ${incorrectKeyCount} incorrect keys in ${options.languages.length} languages.`);
+    failed(`✗ Found ${incorrectKeyCount} incorrect keys in ${options.languages.length} languages.`);
   } else {
-    core.info(`${COLORS.green}✔ No incorrect keys found!`);
+    logInfo(COLORS.green, "✔ No incorrect keys found!");
     process.exitCode = 0;
   }
 }
 
 /**
  * Display the results for the file name format check.
- * @param {incorrectFileNames} result - The incorrect keys found.
- * @param {options} options - The options used.
+ * @param {IncorrectFileNames} result - The incorrect keys found.
+ * @param {Options} options - The options used.
  */
 function displayFileNameResults(result, options) {
-  core.info(`${COLORS.info}File Name Result:`);
+  logInfo(COLORS.info, "File Name Result:");
   if (Object.keys(result).length > 0) {
-    core.setFailed("Found incorrect file names");
+    failed("Found incorrect file names");
     // Log incorrect file names per language
     for (const languageCode of options.languages) {
       const incorrectFileNamesForLang = result[languageCode];
@@ -163,15 +166,15 @@ function displayFileNameResults(result, options) {
       }
       const color = incorrectFileNamesForLang.length > 0 ? COLORS.red : COLORS.green;
 
-      core.startGroup(`${color}Result for ${languageCode}`);
-      core.info(`${color}${languageCode}: ${incorrectFileNamesForLang.length} incorrect file names`);
+      logStartGroup(color, `Result for ${languageCode}`);
+      logInfo(color, `${languageCode}: ${incorrectFileNamesForLang.length} incorrect file names`);
       displayIncorrectFileNames(incorrectFileNamesForLang);
-      core.endGroup();
+      endGroup();
     }
     const incorrectFileNameCount = Object.values(result).reduce((sum, val) => sum + val.length, 0);
-    core.setFailed(`✗ Found ${incorrectFileNameCount} incorrect file names in ${options.languages.length} languages.`);
+    failed(`✗ Found ${incorrectFileNameCount} incorrect file names in ${options.languages.length} languages.`);
   } else {
-    core.info(`${COLORS.green}✔ No incorrect file names found!`);
+    logInfo(COLORS.green, "✔ No incorrect file names found!");
     process.exitCode = 0;
   }
 }
@@ -179,7 +182,7 @@ function displayFileNameResults(result, options) {
 /**
  * Display the incorrect keys for a language.
  * @param {string} languageCode - The language code.
- * @param {incorrectKeys} incorrectKeysForLang - The incorrect keys for the language.
+ * @param {IncorrectKeys} incorrectKeysForLang - The incorrect keys for the language.
  */
 function displayIncorrectKeys(languageCode, incorrectKeysForLang) {
   if (Object.keys(incorrectKeysForLang).length <= 0) {
@@ -190,37 +193,37 @@ function displayIncorrectKeys(languageCode, incorrectKeysForLang) {
       continue;
     }
     // log the filepath
-    core.info(`${COLORS.file}File: ${filePath}`);
+    logInfo(COLORS.file, `File: ${filePath}`);
     for (const incorrectKey of incorrectKeys) {
-      core.info(`${COLORS.red}Incorrect key found at line ${incorrectKey.line}: ${incorrectKey.incorrectKey}`);
-      core.info(`${COLORS.corrected}Correct key: ${incorrectKey.correctedKey}`);
+      logInfo(COLORS.red, `Incorrect key found at line ${incorrectKey.line}: ${incorrectKey.incorrectKey}`);
+      logInfo(COLORS.corrected, `Correct key: ${incorrectKey.correctedKey}`);
     }
   }
 }
 
 /**
  * Display the incorrect keys for a language.
- * @param {incorrectFileName[]} incorrectFileNamesForLang - The incorrect file names for the language.
+ * @param {IncorrectFileName[]} incorrectFileNamesForLang - The incorrect file names for the language.
  */
 function displayIncorrectFileNames(incorrectFileNamesForLang) {
   if (incorrectFileNamesForLang.length <= 0) {
     return;
   }
   for (const incorrectFileName of incorrectFileNamesForLang) {
-    core.info(`${COLORS.red}Incorrect file name: ${incorrectFileName.incorrectFileName}`);
-    core.info(`${COLORS.corrected}Correct file name: ${incorrectFileName.correctedFileName}`);
+    logInfo(COLORS.red, `Incorrect file name: ${incorrectFileName.incorrectFileName}`);
+    logInfo(COLORS.corrected, `Correct file name: ${incorrectFileName.correctedFileName}`);
   }
 }
 
 /**
  * Display the results for the missing key format check.
- * @param {fileKeys} result - The missing keys found.
- * @param {options} options - The options used.
+ * @param {FileKeys} result - The missing keys found.
+ * @param {Options} options - The options used.
  */
 function displayMissingResult(result, options) {
-  core.info(`${COLORS.info}Missing keys Result:`);
+  logInfo(COLORS.info, "Missing keys Result:");
   if (Object.keys(result).length > 0) {
-    core.setFailed("Found missing keys");
+    failed("Found missing keys");
     // Log missing keys per language
     for (const languageCode of options.languages) {
       if (languageCode === mainLanguage) {
@@ -229,16 +232,16 @@ function displayMissingResult(result, options) {
       const missingKeysForLang = Object.entries(result).filter(([path]) => path.includes(`/${languageCode}/`));
       const incorrectKeysCount = missingKeysForLang.reduce((sum, [_, val]) => sum + val.length, 0);
       const color = incorrectKeysCount > 0 ? COLORS.red : COLORS.green;
-      core.startGroup(`${color}Result for ${languageCode}`);
-      core.info(`${color}${languageCode}: ${incorrectKeysCount} missing keys`);
+      logStartGroup(color, `Result for ${languageCode}`);
+      logInfo(color, `${languageCode}: ${incorrectKeysCount} missing keys`);
       // log all missing keys for the language
       displayMissingKeys(languageCode, Object.fromEntries(missingKeysForLang));
-      core.endGroup();
+      endGroup();
     }
     const missingKeyCount = Object.values(result).reduce((sum, val) => sum + val.length, 0);
-    core.setFailed(`✗ Found ${missingKeyCount} missing keys in ${options.languages.length} languages.`);
+    failed(`✗ Found ${missingKeyCount} missing keys in ${options.languages.length} languages.`);
   } else {
-    core.info(`${COLORS.green}✔ No missing keys found!`);
+    logInfo(COLORS.green, "✔ No missing keys found!");
     process.exitCode = 0;
   }
 }
@@ -246,7 +249,7 @@ function displayMissingResult(result, options) {
 /**
  * Display the missing keys for a language.
  * @param {string} languageCode - The language code.
- * @param {fileKeys} missingKeysForLang - The missing keys for the language.
+ * @param {FileKeys} missingKeysForLang - The missing keys for the language.
  */
 function displayMissingKeys(languageCode, missingKeysForLang) {
   if (Object.keys(missingKeysForLang).length <= 0) {
@@ -257,9 +260,9 @@ function displayMissingKeys(languageCode, missingKeysForLang) {
       continue;
     }
     // log the filepath
-    core.info(`${COLORS.file}File: ${filePath}`);
+    logInfo(COLORS.file, `File: ${filePath}`);
     for (const missing of missingKeys) {
-      core.info(`${COLORS.red}Missing key found: ${missing}`);
+      logInfo(COLORS.red, `Missing key found: ${missing}`);
     }
   }
 }

--- a/.github/scripts/locales-format-checker/main.js
+++ b/.github/scripts/locales-format-checker/main.js
@@ -67,8 +67,8 @@ async function main() {
  * @returns {options}
  */
 function parseArgs(args) {
-  const optionArgs = args.filter(arg => arg.startsWith("-"));
-  const languageArgs = args.filter(arg => !arg.startsWith("-"));
+  const optionArgs = args.filter((arg) => arg.startsWith("-"));
+  const languageArgs = args.filter((arg) => !arg.startsWith("-"));
   /** @type {options} */
   const options = {
     checkKeys: false,

--- a/.github/scripts/locales-format-checker/types.js
+++ b/.github/scripts/locales-format-checker/types.js
@@ -1,27 +1,27 @@
 /**
- * @typedef {{ incorrectKey: string, correctedKey: string, line: number }} incorrectKey
+ * @typedef {{ incorrectKey: string, correctedKey: string, line: number }} IncorrectKey
  */
 
 /**
- * @typedef {Object.<string, incorrectKey[]>} incorrectKeys
+ * @typedef {Object.<string, IncorrectKey[]>} IncorrectKeys
  */
 
 /**
- * @typedef {{ checkKeys: boolean, checkFileNames: boolean, checkMissing: boolean, verbose: boolean, languages: string[] }} options
+ * @typedef {{ checkKeys: boolean, checkFileNames: boolean, checkMissing: boolean, verbose: boolean, languages: string[] }} Options
  */
 
 /**
- * @typedef {{ incorrectFileName: string, correctedFileName: string }} incorrectFileName
+ * @typedef {{ incorrectFileName: string, correctedFileName: string }} IncorrectFileName
  */
 
 /**
- * @typedef {Object.<string, incorrectFileName[]} incorrectFileNames
+ * @typedef {Object.<string, IncorrectFileName[]>} IncorrectFileNames
  */
 
 /**
- * @typedef {Object.<string, string[]>} fileKeys
+ * @typedef {Object.<string, string[]>} FileKeys
  */
 
 /**
- * @typedef {"camelCase" | "kebab-case" | "PascalCase" | "snake_case" | "UPPER_SNAKE_CASE" | "Pascal_Snake_Case"} format
+ * @typedef {"camelCase" | "kebab-case" | "PascalCase" | "snake_case" | "UPPER_SNAKE_CASE" | "Pascal_Snake_Case"} Format
  */

--- a/.github/scripts/locales-format-checker/utils.js
+++ b/.github/scripts/locales-format-checker/utils.js
@@ -1,0 +1,34 @@
+import { info, setFailed, startGroup } from "@actions/core";
+import { COLORS } from "./constants.js";
+
+/**
+ * Prints a message to the console with a color code and automatically adds the color reset code at the end.
+ * @param {string} color - The color to apply to the message
+ * @param {string} message - The message to print
+ */
+export function logInfo(color, message) {
+  info(color + message + COLORS.reset);
+}
+
+/**
+ * Prints a message to the console with a color code and automatically adds the color reset code at the end.
+ * @remarks
+ * Begins an output group.
+ *
+ * Output until the next `groupEnd` will be foldable in this group
+ * @param {string} color - The color to apply to the message
+ * @param {string} message - The message to print
+ */
+export function logStartGroup(color, message) {
+  startGroup(color + message + COLORS.reset);
+}
+
+/**
+ * Sets the action status to failed. When the action exits it will be with an exit code of 1.
+ * @remarks
+ * Automatically prepends the red color code and appends the color reset code to the message.
+ * @param {string} message - The message to print
+ */
+export function failed(message) {
+  setFailed(COLORS.red + message + COLORS.reset);
+}

--- a/.github/workflows/check-file-names.yml
+++ b/.github/workflows/check-file-names.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Check file names
 
 on:
   push:
@@ -9,15 +9,14 @@ on:
       - main
 
 jobs:
-  # Checks if any files end with `messages.json` and fails if any are found
   validate-filenames:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
 
-      - name: Filename Inspector
-        uses: scheduleonce/lint-filenames@v2.0.0
+      - name: Block "*messages.json"
+        uses: scheduleonce/lint-filenames@2d348b0e2bf8894288e4a336693bbc19713e978c # 3.0.0
         with:
           pattern: ^(?!.*messages\.json$).* # Match files that do NOT end with 'messages.json'
           path: "**/*.json"

--- a/.github/workflows/check-locales-format.yml
+++ b/.github/workflows/check-locales-format.yml
@@ -1,6 +1,5 @@
 name: Validate locales files for correctness
 on:
-  # adjust for Pokerogue
   pull_request:
     branches:
       - main
@@ -8,23 +7,60 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
 jobs:
+  validator-path-filter:
+    name: Locales validator path filter
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      all: ${{ steps.filter.outputs.all }}
+
+    steps:
+      - name: Checkout GitHub repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
+        with:
+          sparse-checkout: |
+            README.md
+          sparse-checkout-cone-mode: false
+
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # 4.0.2
+        id: filter
+        with:
+          filters: |
+            all:
+              - "**/*.json"
+              - "!package.json"
+              - "!tsconfig.json"
+          predicate-quantifier: "every"
+
   validate-locales-files:
     name: Validate locales files
+    timeout-minutes: 10
     runs-on: ubuntu-latest
+    needs: validator-path-filter
+    if: ${{ needs.validator-path-filter.outputs.all == 'true' && (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'Pontoon:')) }}
+
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # 6.0.9
         with:
           version: 10
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # 6.4.0
         with:
-          node-version: 22.14.0
+          node-version: 24
           cache: "pnpm"
       
       - name: Install Node.js dependencies

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,86 @@
+name: Linting
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  merge_group:
+    types: [checks_requested]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  linting-path-filter:
+    name: Linting path filter
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      all: ${{ steps.filter.outputs.all }}
+
+    steps:
+      - name: Checkout GitHub repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
+        with:
+          sparse-checkout: |
+            README.md
+          sparse-checkout-cone-mode: false
+
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # 4.0.2
+        id: filter
+        with:
+          filters: |
+            all:
+              - "package.json"
+              - "pnpm-lock.yaml"
+              - "tsconfig.json"
+              - "biome.jsonc"
+              - ".github/workflows/linting.yml"
+              - "**/*.mts"
+              - "**/*.js"
+
+  run-linters:
+    name: Run all linters
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    needs: linting-path-filter
+    if: needs.linting-path-filter.outputs.all == 'true'
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
+        with:
+          sparse-checkout: |
+            .github
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # 6.0.9
+        with:
+          version: 10
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # 6.4.0
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm i
+        shell: bash
+
+      - name: Lint with Biome
+        run: pnpm biome:ci
+        if: ${{ !cancelled() }}
+
+      - name: Run Typecheck
+        run: pnpm typecheck
+        if: ${{ !cancelled() }}

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,0 +1,291 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
+
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": {
+          "level": "on",
+          "options": {
+            "groups": [":ALIAS:", ":NODE:", ":PACKAGE_WITH_PROTOCOL:", ":PACKAGE:", ":PATH:"]
+          }
+        },
+        "useSortedPackageJson": "on"
+      }
+    }
+  },
+
+  "files": {
+    "ignoreUnknown": true,
+    "includes": ["**/*.mts", "**/*.js", "biome.jsonc", "package.json"]
+  },
+
+  "formatter": {
+    "enabled": true,
+    "includes": ["**/*.mts", "**/*.js", "biome.jsonc", "package.json"],
+    "indentStyle": "space",
+    "lineWidth": 120,
+    "useEditorconfig": true
+  },
+
+  "javascript": {
+    "formatter": {
+      "operatorLinebreak": "before"
+    },
+    "parser": {
+      "jsxEverywhere": false
+    }
+  },
+
+  "vcs": {
+    "clientKind": "git",
+    "defaultBranch": "main",
+    "enabled": true,
+    "useIgnoreFile": true
+  },
+
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "preset": "recommended",
+
+      "complexity": {
+        "noBannedTypes": "error",
+        "noExcessiveCognitiveComplexity": "info",
+        "noForEach": "off",
+        "noThisInStatic": "error",
+        "noUselessConstructor": "error",
+        "noUselessStringConcat": "error",
+        "noUselessSwitchCase": "off",
+        "noUselessTernary": "error",
+        "noUselessThisAlias": "error",
+        "noUselessUndefined": "error",
+        "noVoid": "error",
+        "useArrayFind": "error",
+        "useIndexOf": "error",
+        "useLiteralKeys": "error",
+        "useRegexLiterals": "error",
+        "useWhile": "error"
+      },
+
+      "correctness": {
+        "noPrivateImports": "error",
+        "noSwitchDeclarations": "error",
+        "noUndeclaredDependencies": "error",
+        "noUndeclaredVariables": "off", // handled by TypeScript
+        "noUnusedFunctionParameters": "error",
+        "noUnusedImports": {
+          "fix": "safe",
+          "level": "error"
+        },
+        "noUnusedLabels": "error",
+        "noUnusedPrivateClassMembers": "error",
+        "noUnusedVariables": "error",
+        "noVoidTypeReturn": "error",
+        "useJsonImportAttributes": "error",
+        "useParseIntRadix": "off",
+        "useSingleJsDocAsterisk": "error"
+      },
+
+      "nursery": {
+        "noFloatingPromises": "error",
+        "noMisusedPromises": "error",
+        "useAwaitThenable": "error",
+        "useExhaustiveSwitchCases": "error",
+        "useExplicitType": "error",
+        "useRegexpExec": "error"
+      },
+
+      "performance": {
+        "noAwaitInLoops": "off",
+        "noBarrelFile": "error",
+        "noDelete": "error",
+        "noNamespaceImport": "error"
+      },
+
+      "style": {
+        "noCommonJs": "error",
+        "noDefaultExport": "error",
+        "noInferrableTypes": "off",
+        "noMultiAssign": "error",
+        "noMultilineString": "error",
+        "noNamespace": "error",
+        "noNegationElse": "error",
+        "noNestedTernary": "error",
+        "noNonNullAssertion": "off",
+        "noParameterAssign": "error",
+        "noParameterProperties": "error",
+        "noShoutyConstants": "error",
+        "noSubstr": "error",
+        "noUnusedTemplateLiteral": "error",
+        "noUselessElse": "error",
+        "noYodaExpression": "error",
+        "useAsConstAssertion": "error",
+        "useAtIndex": "error",
+        "useBlockStatements": {
+          "fix": "safe",
+          "level": "error"
+        },
+        "useCollapsedElseIf": "error",
+        "useCollapsedIf": "error",
+        "useConsistentArrayType": {
+          "fix": "safe",
+          "level": "error"
+        },
+        "useConsistentBuiltinInstantiation": {
+          "fix": "safe",
+          "level": "error"
+        },
+        "useConsistentMemberAccessibility": {
+          "level": "error",
+          "options": {
+            "accessibility": "explicit"
+          }
+        },
+        "useConsistentObjectDefinitions": {
+          "level": "error",
+          "options": {
+            "syntax": "shorthand"
+          }
+        },
+        "useConst": "error",
+        "useDefaultParameterLast": "error",
+        "useDeprecatedReason": "error",
+        "useEnumInitializers": "error",
+        "useExplicitLengthCheck": {
+          "fix": "safe",
+          "level": "error"
+        },
+        "useExponentiationOperator": "off",
+        "useFilenamingConvention": {
+          "level": "error",
+          "options": {
+            "filenameCases": ["kebab-case"],
+            "requireAscii": true,
+            "strictCase": false
+          }
+        },
+        "useForOf": "error",
+        "useGroupedAccessorPairs": "error",
+        "useImportType": "error",
+        "useNamingConvention": {
+          "level": "error",
+          "options": {
+            // evaluated in order from top to bottom
+            "conventions": [
+              {
+                "formats": ["PascalCase"],
+                "selector": {
+                  "kind": "interface"
+                }
+              },
+              {
+                "formats": ["PascalCase"],
+                "selector": {
+                  "kind": "typeAlias"
+                }
+              },
+              {
+                "formats": ["PascalCase"],
+                "selector": {
+                  "kind": "class"
+                }
+              },
+              {
+                "formats": ["PascalCase"],
+                "selector": {
+                  "kind": "enum"
+                }
+              },
+              {
+                "formats": ["CONSTANT_CASE"],
+                "selector": {
+                  "kind": "enumMember"
+                }
+              },
+              // having this section last disables the built-in conventions
+              {
+                "match": ".*"
+              }
+            ],
+            "requireAscii": true,
+            "strictCase": false
+          }
+        },
+        "useNodejsImportProtocol": "error",
+        "useNumberNamespace": "error",
+        "useNumericSeparators": "off", // TODO: enable?
+        "useObjectSpread": "error",
+        "useReadonlyClassProperties": {
+          "level": "error",
+          "options": {
+            "checkAllProperties": false
+          }
+        },
+        "useShorthandAssign": {
+          "fix": "safe",
+          "level": "error"
+        },
+        "useSingleVarDeclarator": {
+          "fix": "safe",
+          "level": "error"
+        },
+        "useSpreadOverApply": "error",
+        "useTemplate": "off",
+        "useThrowNewError": {
+          "fix": "safe",
+          "level": "error"
+        },
+        "useThrowOnlyError": "error",
+        "useTrimStartEnd": "error",
+        "useUnifiedTypeSignatures": {
+          "fix": "unsafe",
+          "level": "error",
+          "options": {
+            "ignoreDifferentJsDoc": true,
+            "ignoreDifferentlyNamedParameters": true
+          }
+        }
+      },
+
+      "suspicious": {
+        "noAssignInExpressions": "error",
+        "noAsyncPromiseExecutor": "error",
+        "noConstantBinaryExpressions": "error",
+        "noDocumentCookie": "off",
+        "noDoubleEquals": "error",
+        "noDuplicateDependencies": "error",
+        "noEvolvingTypes": "error",
+        "noExplicitAny": "off",
+        "noExtraNonNullAssertion": "error",
+        "noFallthroughSwitchClause": "error",
+        "noGlobalIsFinite": "error",
+        "noGlobalIsNan": "error",
+        "noImplicitAnyLet": "error",
+        "noImportCycles": "error",
+        "noNestedPromises": "error",
+        "noNonNullAssertedOptionalChain": "error",
+        "noParametersOnlyUsedInRecursion": "error",
+        "noProto": "error",
+        "noPrototypeBuiltins": "error",
+        "noRedeclare": "error",
+        "noReturnAssign": "error",
+        "noShadow": "error",
+        "noTsIgnore": "error",
+        "noUnnecessaryConditions": "warn",
+        "noVar": "error",
+        "useArraySortCompare": "error",
+        "useDefaultSwitchClauseLast": "error",
+        "useErrorMessage": "error",
+        "useGuardForIn": "error",
+        "useIterableCallbackReturn": {
+          "level": "error",
+          "options": {
+            "checkForEach": false
+          }
+        },
+        "useNumberToFixedDigitsArgument": "error"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,20 +1,28 @@
 {
   "name": "pokerogue-locales",
   "version": "1.0.0",
-  "type": "module",
   "private": true,
+  "type": "module",
   "scripts": {
+    "biome": "biome check --write --changed --no-errors-on-unmatched --diagnostic-level=error --reporter=summary",
+    "biome:all": "biome check --write --no-errors-on-unmatched --diagnostic-level=error --reporter=summary",
+    "biome:ci": "biome ci --diagnostic-level=error --reporter=github --reporter=default --no-errors-on-unmatched",
+    "biome:staged": "biome check --write --staged --no-errors-on-unmatched --diagnostic-level=error --reporter=summary",
     "check-locales-format": "node ./.github/scripts/locales-format-checker/main.js",
-    "check-locales-format:keys": "node ./.github/scripts/locales-format-checker/main.js -k -v",
     "check-locales-format:files": "node ./.github/scripts/locales-format-checker/main.js -f -v",
+    "check-locales-format:keys": "node ./.github/scripts/locales-format-checker/main.js -k -v",
     "check-locales-format:missing": "node ./.github/scripts/locales-format-checker/main.js -m -v",
-    "edit-locales": "node ./.github/scripts/locales-cli-editor/main.js"
+    "edit-locales": "node ./.github/scripts/locales-cli-editor/main.js",
+    "typecheck": "tsc"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.5.1",
+    "@inquirer/prompts": "^8.5.2",
+    "@types/node": "^24.13.3",
+    "chalk": "^5.6.2",
+    "typescript": "^6.0.3"
   },
   "optionalDependencies": {
     "@actions/core": "^1.11.1"
-  },
-  "devDependencies": {
-    "@inquirer/prompts": "^8.1.0",
-    "chalk": "^5.4.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,21 @@ importers:
 
   .:
     devDependencies:
+      '@biomejs/biome':
+        specifier: 2.5.1
+        version: 2.5.1
       '@inquirer/prompts':
-        specifier: ^8.1.0
-        version: 8.2.0
+        specifier: ^8.5.2
+        version: 8.5.2(@types/node@24.13.3)
+      '@types/node':
+        specifier: ^24.13.3
+        version: 24.13.3
       chalk:
-        specifier: ^5.4.1
+        specifier: ^5.6.2
         version: 5.6.2
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
     optionalDependencies:
       '@actions/core':
         specifier: ^1.11.1
@@ -33,172 +42,226 @@ packages:
   '@actions/io@1.1.3':
     resolution: {integrity: sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==}
 
+  '@biomejs/biome@2.5.1':
+    resolution: {integrity: sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.5.1':
+    resolution: {integrity: sha512-npqDzvqv7vFaWRiNN1Te71siRgPaqS9MpqgYCdP/CrUbkJ7ApezaeaKjueKHRN/JH/6lRjJQAHi8acQDCAz22w==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.5.1':
+    resolution: {integrity: sha512-RgwTqPAM8g2tn1j+b5oRjF/DbSBX8a4gwojtuG9XuhfK7GgomvZ9+T+tqjXiVbjLEeGJOoL6VEk8mvRTVeSybw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.5.1':
+    resolution: {integrity: sha512-WMcvMLgByyTqVxGlq918NBBYliq9FRR9GAQVETHb+VjGVqXCZFfHlZHC1FX4ibuYY/Hg6TJE3rHU0xVrdJXNRw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-arm64@2.5.1':
+    resolution: {integrity: sha512-yhV35CzZh38VyMvTEXi3JTjxZBs++oCKK9KG8vB6VI5+uvQvZNR3BFWEKKzuOmx9DJJj7sQpZ4LQJcmbGTs3+Q==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-linux-x64-musl@2.5.1':
+    resolution: {integrity: sha512-ANTowtlLmPYm5yeMckWY8Xzb9Ix+JJP3tgHR/n6xRj1VWyIzzWtfRfih9hv9VmClwadpBvZduISZIbBsIlYG3A==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-x64@2.5.1':
+    resolution: {integrity: sha512-J/7uHSX7NfoYDI7HijAkd8lnQIOrRb2W7j3X+tw4R+N5ExvXGsyXFiGdQcfcxfOmNQmZVSQOCDk757fwpzqQcg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-win32-arm64@2.5.1':
+    resolution: {integrity: sha512-zgXnKNgWPC4iPF7Y1lR3STUeCUuZRpD6IiOrC7TZTlh0Lx6FiVUT05myuMQHQ9D+1cc7uyMldi4forE6lp0ivQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.5.1':
+    resolution: {integrity: sha512-6uxpR9hvaglANkZemeSiN/FhYgkGasrEGn267eXIWvjrjJ2LhDlk251IhjVJq6MXzkV2/bcXwLwSroLyPtqRZg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
+
   '@fastify/busboy@2.1.1':
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
 
-  '@inquirer/ansi@2.0.3':
-    resolution: {integrity: sha512-g44zhR3NIKVs0zUesa4iMzExmZpLUdTLRMCStqX3GE5NT6VkPcxQGJ+uC8tDgBUC/vB1rUhUd55cOf++4NZcmw==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/ansi@2.0.7':
+    resolution: {integrity: sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
 
-  '@inquirer/checkbox@5.0.4':
-    resolution: {integrity: sha512-DrAMU3YBGMUAp6ArwTIp/25CNDtDbxk7UjIrrtM25JVVrlVYlVzHh5HR1BDFu9JMyUoZ4ZanzeaHqNDttf3gVg==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/checkbox@5.2.1':
+    resolution: {integrity: sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/confirm@6.0.4':
-    resolution: {integrity: sha512-WdaPe7foUnoGYvXzH4jp4wH/3l+dBhZ3uwhKjXjwdrq5tEIFaANxj6zrGHxLdsIA0yKM0kFPVcEalOZXBB5ISA==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/confirm@6.1.1':
+    resolution: {integrity: sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/core@11.1.1':
-    resolution: {integrity: sha512-hV9o15UxX46OyQAtaoMqAOxGR8RVl1aZtDx1jHbCtSJy1tBdTfKxLPKf7utsE4cRy4tcmCQ4+vdV+ca+oNxqNA==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/core@11.2.1':
+    resolution: {integrity: sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/editor@5.0.4':
-    resolution: {integrity: sha512-QI3Jfqcv6UO2/VJaEFONH8Im1ll++Xn/AJTBn9Xf+qx2M+H8KZAdQ5sAe2vtYlo+mLW+d7JaMJB4qWtK4BG3pw==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/editor@5.2.2':
+    resolution: {integrity: sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/expand@5.0.4':
-    resolution: {integrity: sha512-0I/16YwPPP0Co7a5MsomlZLpch48NzYfToyqYAOWtBmaXSB80RiNQ1J+0xx2eG+Wfxt0nHtpEWSRr6CzNVnOGg==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/expand@5.1.1':
+    resolution: {integrity: sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/external-editor@2.0.3':
-    resolution: {integrity: sha512-LgyI7Agbda74/cL5MvA88iDpvdXI2KuMBCGRkbCl2Dg1vzHeOgs+s0SDcXV7b+WZJrv2+ERpWSM65Fpi9VfY3w==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/external-editor@3.0.3':
+    resolution: {integrity: sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/figures@2.0.3':
-    resolution: {integrity: sha512-y09iGt3JKoOCBQ3w4YrSJdokcD8ciSlMIWsD+auPu+OZpfxLuyz+gICAQ6GCBOmJJt4KEQGHuZSVff2jiNOy7g==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/figures@2.0.7':
+    resolution: {integrity: sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
 
-  '@inquirer/input@5.0.4':
-    resolution: {integrity: sha512-4B3s3jvTREDFvXWit92Yc6jF1RJMDy2VpSqKtm4We2oVU65YOh2szY5/G14h4fHlyQdpUmazU5MPCFZPRJ0AOw==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/input@5.1.2':
+    resolution: {integrity: sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/number@4.0.4':
-    resolution: {integrity: sha512-CmMp9LF5HwE+G/xWsC333TlCzYYbXMkcADkKzcawh49fg2a1ryLc7JL1NJYYt1lJ+8f4slikNjJM9TEL/AljYQ==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/number@4.1.1':
+    resolution: {integrity: sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/password@5.0.4':
-    resolution: {integrity: sha512-ZCEPyVYvHK4W4p2Gy6sTp9nqsdHQCfiPXIP9LbJVW4yCinnxL/dDDmPaEZVysGrj8vxVReRnpfS2fOeODe9zjg==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/password@5.1.1':
+    resolution: {integrity: sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/prompts@8.2.0':
-    resolution: {integrity: sha512-rqTzOprAj55a27jctS3vhvDDJzYXsr33WXTjODgVOru21NvBo9yIgLIAf7SBdSV0WERVly3dR6TWyp7ZHkvKFA==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/prompts@8.5.2':
+    resolution: {integrity: sha512-IYR/3C/paEVVQYQvdDlFZVjRCJVYHHON0XXMH91KO9GSxs0TdKYWlUdvfQl2EfAHDxUaN3IBffkE/BDTh5nJ6g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/rawlist@5.2.0':
-    resolution: {integrity: sha512-CciqGoOUMrFo6HxvOtU5uL8fkjCmzyeB6fG7O1vdVAZVSopUBYECOwevDBlqNLyyYmzpm2Gsn/7nLrpruy9RFg==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/rawlist@5.3.1':
+    resolution: {integrity: sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/search@4.1.0':
-    resolution: {integrity: sha512-EAzemfiP4IFvIuWnrHpgZs9lAhWDA0GM3l9F4t4mTQ22IFtzfrk8xbkMLcAN7gmVML9O/i+Hzu8yOUyAaL6BKA==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/search@4.2.1':
+    resolution: {integrity: sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/select@5.0.4':
-    resolution: {integrity: sha512-s8KoGpPYMEQ6WXc0dT9blX2NtIulMdLOO3LA1UKOiv7KFWzlJ6eLkEYTDBIi+JkyKXyn8t/CD6TinxGjyLt57g==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/select@5.2.1':
+    resolution: {integrity: sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/type@4.0.3':
-    resolution: {integrity: sha512-cKZN7qcXOpj1h+1eTTcGDVLaBIHNMT1Rz9JqJP5MnEJ0JhgVWllx7H/tahUp5YEK1qaByH2Itb8wLG/iScD5kw==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+  '@inquirer/type@4.0.7':
+    resolution: {integrity: sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  ansi-regex@6.2.2:
-    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
-    engines: {node: '>=12'}
-
-  ansi-styles@6.2.3:
-    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
-    engines: {node: '>=12'}
+  '@types/node@24.13.3':
+    resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
-  chardet@2.1.1:
-    resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+  chardet@2.2.0:
+    resolution: {integrity: sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==}
 
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
 
-  emoji-regex@10.6.0:
-    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
 
-  get-east-asian-width@1.4.0:
-    resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
-    engines: {node: '>=18'}
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  iconv-lite@0.7.2:
-    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
     engines: {node: '>=0.10.0'}
 
   mute-stream@3.0.0:
@@ -212,25 +275,21 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
-  string-width@7.2.0:
-    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
-    engines: {node: '>=18'}
-
-  strip-ansi@7.1.2:
-    resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
-    engines: {node: '>=12'}
-
   tunnel@0.0.6:
     resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
     engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
 
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
   undici@5.29.0:
     resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
     engines: {node: '>=14.0'}
-
-  wrap-ansi@9.0.2:
-    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
-    engines: {node: '>=18'}
 
 snapshots:
 
@@ -254,115 +313,184 @@ snapshots:
   '@actions/io@1.1.3':
     optional: true
 
+  '@biomejs/biome@2.5.1':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.5.1
+      '@biomejs/cli-darwin-x64': 2.5.1
+      '@biomejs/cli-linux-arm64': 2.5.1
+      '@biomejs/cli-linux-arm64-musl': 2.5.1
+      '@biomejs/cli-linux-x64': 2.5.1
+      '@biomejs/cli-linux-x64-musl': 2.5.1
+      '@biomejs/cli-win32-arm64': 2.5.1
+      '@biomejs/cli-win32-x64': 2.5.1
+
+  '@biomejs/cli-darwin-arm64@2.5.1':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.5.1':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.5.1':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.5.1':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.5.1':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.5.1':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.5.1':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.5.1':
+    optional: true
+
   '@fastify/busboy@2.1.1':
     optional: true
 
-  '@inquirer/ansi@2.0.3': {}
+  '@inquirer/ansi@2.0.7': {}
 
-  '@inquirer/checkbox@5.0.4':
+  '@inquirer/checkbox@5.2.1(@types/node@24.13.3)':
     dependencies:
-      '@inquirer/ansi': 2.0.3
-      '@inquirer/core': 11.1.1
-      '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@24.13.3)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
 
-  '@inquirer/confirm@6.0.4':
+  '@inquirer/confirm@6.1.1(@types/node@24.13.3)':
     dependencies:
-      '@inquirer/core': 11.1.1
-      '@inquirer/type': 4.0.3
+      '@inquirer/core': 11.2.1(@types/node@24.13.3)
+      '@inquirer/type': 4.0.7(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
 
-  '@inquirer/core@11.1.1':
+  '@inquirer/core@11.2.1(@types/node@24.13.3)':
     dependencies:
-      '@inquirer/ansi': 2.0.3
-      '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@24.13.3)
       cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.2
       mute-stream: 3.0.0
       signal-exit: 4.1.0
-      wrap-ansi: 9.0.2
+    optionalDependencies:
+      '@types/node': 24.13.3
 
-  '@inquirer/editor@5.0.4':
+  '@inquirer/editor@5.2.2(@types/node@24.13.3)':
     dependencies:
-      '@inquirer/core': 11.1.1
-      '@inquirer/external-editor': 2.0.3
-      '@inquirer/type': 4.0.3
+      '@inquirer/core': 11.2.1(@types/node@24.13.3)
+      '@inquirer/external-editor': 3.0.3(@types/node@24.13.3)
+      '@inquirer/type': 4.0.7(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
 
-  '@inquirer/expand@5.0.4':
+  '@inquirer/expand@5.1.1(@types/node@24.13.3)':
     dependencies:
-      '@inquirer/core': 11.1.1
-      '@inquirer/type': 4.0.3
+      '@inquirer/core': 11.2.1(@types/node@24.13.3)
+      '@inquirer/type': 4.0.7(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
 
-  '@inquirer/external-editor@2.0.3':
+  '@inquirer/external-editor@3.0.3(@types/node@24.13.3)':
     dependencies:
-      chardet: 2.1.1
-      iconv-lite: 0.7.2
+      chardet: 2.2.0
+      iconv-lite: 0.7.3
+    optionalDependencies:
+      '@types/node': 24.13.3
 
-  '@inquirer/figures@2.0.3': {}
+  '@inquirer/figures@2.0.7': {}
 
-  '@inquirer/input@5.0.4':
+  '@inquirer/input@5.1.2(@types/node@24.13.3)':
     dependencies:
-      '@inquirer/core': 11.1.1
-      '@inquirer/type': 4.0.3
+      '@inquirer/core': 11.2.1(@types/node@24.13.3)
+      '@inquirer/type': 4.0.7(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
 
-  '@inquirer/number@4.0.4':
+  '@inquirer/number@4.1.1(@types/node@24.13.3)':
     dependencies:
-      '@inquirer/core': 11.1.1
-      '@inquirer/type': 4.0.3
+      '@inquirer/core': 11.2.1(@types/node@24.13.3)
+      '@inquirer/type': 4.0.7(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
 
-  '@inquirer/password@5.0.4':
+  '@inquirer/password@5.1.1(@types/node@24.13.3)':
     dependencies:
-      '@inquirer/ansi': 2.0.3
-      '@inquirer/core': 11.1.1
-      '@inquirer/type': 4.0.3
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@24.13.3)
+      '@inquirer/type': 4.0.7(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
 
-  '@inquirer/prompts@8.2.0':
+  '@inquirer/prompts@8.5.2(@types/node@24.13.3)':
     dependencies:
-      '@inquirer/checkbox': 5.0.4
-      '@inquirer/confirm': 6.0.4
-      '@inquirer/editor': 5.0.4
-      '@inquirer/expand': 5.0.4
-      '@inquirer/input': 5.0.4
-      '@inquirer/number': 4.0.4
-      '@inquirer/password': 5.0.4
-      '@inquirer/rawlist': 5.2.0
-      '@inquirer/search': 4.1.0
-      '@inquirer/select': 5.0.4
+      '@inquirer/checkbox': 5.2.1(@types/node@24.13.3)
+      '@inquirer/confirm': 6.1.1(@types/node@24.13.3)
+      '@inquirer/editor': 5.2.2(@types/node@24.13.3)
+      '@inquirer/expand': 5.1.1(@types/node@24.13.3)
+      '@inquirer/input': 5.1.2(@types/node@24.13.3)
+      '@inquirer/number': 4.1.1(@types/node@24.13.3)
+      '@inquirer/password': 5.1.1(@types/node@24.13.3)
+      '@inquirer/rawlist': 5.3.1(@types/node@24.13.3)
+      '@inquirer/search': 4.2.1(@types/node@24.13.3)
+      '@inquirer/select': 5.2.1(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
 
-  '@inquirer/rawlist@5.2.0':
+  '@inquirer/rawlist@5.3.1(@types/node@24.13.3)':
     dependencies:
-      '@inquirer/core': 11.1.1
-      '@inquirer/type': 4.0.3
+      '@inquirer/core': 11.2.1(@types/node@24.13.3)
+      '@inquirer/type': 4.0.7(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
 
-  '@inquirer/search@4.1.0':
+  '@inquirer/search@4.2.1(@types/node@24.13.3)':
     dependencies:
-      '@inquirer/core': 11.1.1
-      '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3
+      '@inquirer/core': 11.2.1(@types/node@24.13.3)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
 
-  '@inquirer/select@5.0.4':
+  '@inquirer/select@5.2.1(@types/node@24.13.3)':
     dependencies:
-      '@inquirer/ansi': 2.0.3
-      '@inquirer/core': 11.1.1
-      '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@24.13.3)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@24.13.3)
+    optionalDependencies:
+      '@types/node': 24.13.3
 
-  '@inquirer/type@4.0.3': {}
+  '@inquirer/type@4.0.7(@types/node@24.13.3)':
+    optionalDependencies:
+      '@types/node': 24.13.3
 
-  ansi-regex@6.2.2: {}
-
-  ansi-styles@6.2.3: {}
+  '@types/node@24.13.3':
+    dependencies:
+      undici-types: 7.18.2
 
   chalk@5.6.2: {}
 
-  chardet@2.1.1: {}
+  chardet@2.2.0: {}
 
   cli-width@4.1.0: {}
 
-  emoji-regex@10.6.0: {}
+  fast-string-truncated-width@3.0.3: {}
 
-  get-east-asian-width@1.4.0: {}
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
 
-  iconv-lite@0.7.2:
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
+
+  iconv-lite@0.7.3:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -372,26 +500,14 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  string-width@7.2.0:
-    dependencies:
-      emoji-regex: 10.6.0
-      get-east-asian-width: 1.4.0
-      strip-ansi: 7.1.2
-
-  strip-ansi@7.1.2:
-    dependencies:
-      ansi-regex: 6.2.2
-
   tunnel@0.0.6:
     optional: true
+
+  typescript@6.0.3: {}
+
+  undici-types@7.18.2: {}
 
   undici@5.29.0:
     dependencies:
       '@fastify/busboy': 2.1.1
     optional: true
-
-  wrap-ansi@9.0.2:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 7.2.0
-      strip-ansi: 7.1.2

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "include": ["**/*.mts", ".github/**/*.mts", "**/*.js", ".github/**/*.js"],
+  "compilerOptions": {
+    "module": "nodenext",
+    "target": "esnext",
+    "strict": true,
+    "useUnknownInCatchVariables": false,
+    "erasableSyntaxOnly": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    // Node needs the .ts extensions to run properly
+    "allowImportingTsExtensions": true,
+    // TODO: convert js files to mts
+    "allowJs": true,
+    "checkJs": true
+  }
+}


### PR DESCRIPTION
- Added Biome and TypeScript as dev dependencies and fixed up all the lint/type errors in the script files.
- Added a workflow to lint/typecheck the scripts.
- Updated the actions in the workflows and pinned them to a SHA.
- Added a path filter to the locales file check workflow so it doesn't run if:
  - no locales files were changed, or
  - it was an automated commit to main from Pontoon
- Fixed a bug where the color reset codes were missing from the console logs, causing the CLI to be permanently colored after using the check locales script.
- Removed `async`/promises from a couple of functions that didn't need to be `async`.

There will be a follow-up converting them from JavaScript to TypeScript, but I want to make sure to preserve the git history and changing too much in the files while renaming them at the same time will cause it to be lost (git will just see the `.js` file being deleted and a `.mts` file being added).