### PR TITLE
Add message for indicating a fainted Pokemon can't be chosen

### DIFF
--- a/en/party-ui-handler.json
+++ b/en/party-ui-handler.json
@@ -26,6 +26,7 @@
   "noEnergy": "{{pokemonName}} has no energy\nleft to battle!",
   "hasEnergy": "{{pokemonName}} still has energy\nto battle!",
   "cantBeUsed": "{{pokemonName}} can’t be used in\nthis challenge!",
+  "noFaintedPokemon": "Fainted Pokémon can't be chosen!",
   "tooManyItems": "{{pokemonName}} has too many\nof this item!",
   "anyEffect": "It won’t have any effect.",
   "unpausedEvolutions": "Evolutions have been unpaused for {{pokemonName}}.",


### PR DESCRIPTION
## Explanation of Changes
- Main repo PR: https://github.com/pagefaultgames/pokerogue/pull/7610

## Screenshots/Videos
<details><summary>Screenshot</summary>

<img width="1236" height="693" alt="image" src="https://github.com/user-attachments/assets/7c2148ea-e1cd-4c0e-be95-b1faa6871294" />

</details> 

## Checklist
- [x] I have provided **screenshots** proving my additions are properly working (if necessary).
- [x] I have attached a link to a main repo PR or properly explained my changes as applicable.
- [x] I have notified Translation staff on Discord about the existence of this PR.
- ~[ ] I have uncommented the appropriate warning message if necessary.~
