### PR TITLE
Add locales for the Ability Randomizer challenge

### DIFF
--- a/en/challenges.json
+++ b/en/challenges.json
@@ -119,5 +119,18 @@
       "0": "Off",
       "1": "On"
     }
+  },
+  "abilityRandomizer": {
+    "name": "Ability Randomizer",
+    "desc": {
+      "0": "Randomizes the abilities (and optionally passives) of each Pokémon species.\n\nDisables other challenges’ achievements.",
+      "1": "Randomizes the abilities of each Pokémon species.\n\nDisables other challenges’ achievements.",
+      "2": "Randomizes the abilities and passives of each Pokémon species.\n\nDisables other challenges’ achievements."
+    },
+    "value": {
+      "0": "Off",
+      "1": "Abilities",
+      "2": "All"
+    }
   }
 }


### PR DESCRIPTION
## Explanation of Changes
- Main repo PR: https://github.com/pagefaultgames/pokerogue/pull/7647

## Screenshots/Videos
<details><summary>Challenge off</summary>

<img width="1230" height="691" alt="image" src="https://github.com/user-attachments/assets/9731affd-ef6e-4097-bac1-4945b07ae625" />

</details>
<details><summary>Challenge on (abilities only)</summary>

<img width="1236" height="692" alt="image" src="https://github.com/user-attachments/assets/5af129a1-767a-4042-a9e8-1e57b0fcb028" />

</details>
<details><summary>Challenge on (abilities and passives)</summary>

<img width="1231" height="691" alt="image" src="https://github.com/user-attachments/assets/5db21508-9a8f-4112-b1b6-28ad36a2d63a" />

</details>

## Checklist
- [x] I have provided **screenshots** proving my additions are properly working (if necessary).
- [x] I have attached a link to a main repo PR or properly explained my changes as applicable.
- [x] I have notified Translation staff on Discord about the existence of this PR.
- ~[ ] I have uncommented the appropriate warning message if necessary.~
